### PR TITLE
Correct error message wording in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Total: 100 / 100
 
 If you have made no past (successful) submissions, then your output may look like:
 ```
-No past submission found for this assignment.
+No matching submission found.
 ```
 
 #### Getting a History of All Past Submissions
@@ -162,7 +162,7 @@ Found 2 submissions.
 
 If you have made no past (successful) submissions, then your output may look like:
 ```
-No past submission found for this assignment.
+No matching submission found.
 ```
 
 ### Commands for TAs and Instructors


### PR DESCRIPTION
A CSE114A student pointed out that it's actually "No matching submission found." rather than "No past submission found for this assignment."