### PR TITLE
Require acknowledgment for late submissions

### DIFF
--- a/autograder/api/submission/submit.py
+++ b/autograder/api/submission/submit.py
@@ -8,6 +8,7 @@ API_PARAMS = [
     autograder.api.config.PARAM_USER_PASS,
     autograder.api.config.PARAM_ASSIGNMENT_ID,
 
+    autograder.api.config.APIParam('late-acknowledgment', 'Acknowledge that the late policy will be applied.', required = False),
     autograder.api.config.APIParam('message',
         'An optional message to attatch to the submission.',
         required = False)

--- a/autograder/cli/submission/submit.py
+++ b/autograder/cli/submission/submit.py
@@ -2,6 +2,7 @@ import sys
 
 import autograder.api.submission.submit
 import autograder.assignment
+from autograder.util.confirm import confirm
 
 def run(arguments):
     result = autograder.api.submission.submit.send(arguments, arguments.files, exit_on_error = True)
@@ -13,6 +14,10 @@ def run(arguments):
         print("-------------------------------")
 
     if (result['rejected']):
+        if result['require-late-acknowledgment']:
+            if confirm("This assignment is past the due date and the late policy will be applied. Do you want to continue?"):
+                setattr(arguments, "late-acknowledgment", True)
+                return run(arguments)
         print("Submission was rejected by the autograder.")
         return 1
 

--- a/autograder/util/confirm.py
+++ b/autograder/util/confirm.py
@@ -1,0 +1,35 @@
+def confirm(prompt, default="no"):
+    """
+    Prompts the user for a confirmation and returns a boolean value based on their response.
+
+    Args:
+        prompt (str): The prompt message to display to the user.
+        default (str, optional, "yes" or "no"): The default answer if no input is provided. Defaults to "no".
+
+    Returns:
+        bool: True if the user confirms with 'yes' or 'y', False if the user hits enter or enters 'no' or 'n'.
+    """
+    valid = {"yes": True, "y": True, "no": False, "n": False}
+
+    if default not in valid:
+        raise ValueError(
+            "Invalid default answer: '{}', expected 'yes' or 'no'.".format(default)
+        )
+
+    # Set the default response in the prompt message
+    if default == "yes":
+        prompt += " [Y/n] "
+    else:
+        prompt += " [y/N] "
+
+    while True:
+        choice = input(prompt).strip().lower()
+
+        # If no input is provided, use the default value
+        if choice == "":
+            return valid[default]
+
+        if choice in valid:
+            return valid[choice]
+
+        print("Please answer with 'yes' or 'no'.")


### PR DESCRIPTION
This PR is the client counterpart of https://github.com/edulinq/autograder-server/pull/74

It changes the `autograder.cli.submission.submit` to check the `require-late-acknowledgment` field in case of rejection, and if the field is set to true, prompts the user if they still want to submit, and submit again with the `late-acknowledgment` flag.