### PR TITLE
Added support for the users/remove API endpoint.

### DIFF
--- a/autograder/api/users/remove.py
+++ b/autograder/api/users/remove.py
@@ -1,0 +1,22 @@
+import autograder.api.common
+import autograder.api.config
+
+API_ENDPOINT = 'users/remove'
+API_PARAMS = [
+    autograder.api.config.PARAM_USER_EMAIL,
+    autograder.api.config.PARAM_USER_PASS,
+
+    autograder.api.config.PARAM_TARGET_EMAIL,
+]
+
+DESCRIPTION = 'Remove a user from the server.'
+
+def send(arguments, **kwargs):
+    return autograder.api.common.handle_api_request(arguments, API_PARAMS, API_ENDPOINT, **kwargs)
+
+def _get_parser():
+    parser = autograder.api.config.get_argument_parser(
+        description = DESCRIPTION,
+        params = API_PARAMS)
+
+    return parser

--- a/autograder/cli/users/remove.py
+++ b/autograder/cli/users/remove.py
@@ -5,11 +5,11 @@ import autograder.api.users.remove
 def run(arguments):
     result = autograder.api.users.remove.send(arguments, exit_on_error = True)
 
-    if (result['found-user']):
-        print("User removed.")
-    else:
+    if (not result['found-user']):
         print("User not found.")
+        return 1
 
+    print("User removed.")
     return 0
 
 def main():

--- a/autograder/cli/users/remove.py
+++ b/autograder/cli/users/remove.py
@@ -1,0 +1,23 @@
+import sys
+
+import autograder.api.users.remove
+
+def run(arguments):
+    result = autograder.api.users.remove.send(arguments, exit_on_error = True)
+
+    if (result['found-user']):
+        print("User removed.")
+    else:
+        print("User not found.")
+
+    return 0
+
+def main():
+    return run(_get_parser().parse_args())
+
+def _get_parser():
+    parser = autograder.api.users.remove._get_parser()
+    return parser
+
+if (__name__ == '__main__'):
+    sys.exit(main())

--- a/tests/api/testdata/users_remove_base.json
+++ b/tests/api/testdata/users_remove_base.json
@@ -1,0 +1,11 @@
+{
+    "module": "autograder.api.users.remove",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-email": "server-user@test.edulinq.org"
+    },
+    "output": {
+        "found-user": true
+    }
+}

--- a/tests/api/testdata/users_remove_missing.json
+++ b/tests/api/testdata/users_remove_missing.json
@@ -1,0 +1,11 @@
+{
+    "module": "autograder.api.users.remove",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-email": "ZZZ@test.edulinq.org"
+    },
+    "output": {
+        "found-user": false
+    }
+}

--- a/tests/cli/testdata/users/users_remove_base.txt
+++ b/tests/cli/testdata/users/users_remove_base.txt
@@ -1,0 +1,10 @@
+{
+    "cli": "autograder.cli.users.remove",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "server-user@test.edulinq.org"
+    ]
+}
+---
+User removed.

--- a/tests/cli/testdata/users/users_remove_missing.txt
+++ b/tests/cli/testdata/users/users_remove_missing.txt
@@ -4,7 +4,8 @@
         "--user", "server-admin@test.edulinq.org",
         "--pass", "server-admin",
         "--target-email", "ZZZ@test.edulinq.org"
-    ]
+    ],
+    "exit-status": 1
 }
 ---
 User not found.

--- a/tests/cli/testdata/users/users_remove_missing.txt
+++ b/tests/cli/testdata/users/users_remove_missing.txt
@@ -1,0 +1,10 @@
+{
+    "cli": "autograder.cli.users.remove",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "ZZZ@test.edulinq.org"
+    ]
+}
+---
+User not found.


### PR DESCRIPTION
This is the python interface for the new API endpoint: users/remove.

This PR must be reviewed with the corresponding [server PR](https://github.com/edulinq/autograder-server/pull/95).