### PR TITLE
Added support for the courses/users/drop API endpoint.

### DIFF
--- a/autograder/api/courses/users/drop.py
+++ b/autograder/api/courses/users/drop.py
@@ -1,0 +1,25 @@
+import autograder.api.common
+import autograder.api.config
+
+API_ENDPOINT = 'courses/users/drop'
+
+API_PARAMS = [
+    autograder.api.config.PARAM_USER_EMAIL,
+    autograder.api.config.PARAM_USER_PASS,
+
+    autograder.api.config.PARAM_COURSE_ID,
+
+    autograder.api.config.PARAM_TARGET_EMAIL,
+]
+
+DESCRIPTION = 'Drop a user from the course.'
+
+def send(arguments, **kwargs):
+    return autograder.api.common.handle_api_request(arguments, API_PARAMS, API_ENDPOINT, **kwargs)
+
+def _get_parser():
+    parser = autograder.api.config.get_argument_parser(
+        description = DESCRIPTION,
+        params = API_PARAMS)
+
+    return parser

--- a/autograder/cli/courses/users/__main__.py
+++ b/autograder/cli/courses/users/__main__.py
@@ -1,0 +1,13 @@
+"""
+The `autograder.cli.courses.users` package contains tools to manage autograder course users.
+"""
+
+import sys
+
+import autograder.util.cli
+
+def main():
+    return autograder.util.cli.main()
+
+if (__name__ == '__main__'):
+    sys.exit(main())

--- a/autograder/cli/courses/users/drop.py
+++ b/autograder/cli/courses/users/drop.py
@@ -1,0 +1,23 @@
+import sys
+
+import autograder.api.courses.users.drop
+
+def run(arguments):
+    result = autograder.api.courses.users.drop.send(arguments, exit_on_error = True)
+
+    if (not result['found-user']):
+        print("User not found.")
+        return 1
+
+    print("User dropped.")
+    return 0
+
+def main():
+    return run(_get_parser().parse_args())
+
+def _get_parser():
+    parser = autograder.api.courses.users.drop._get_parser()
+    return parser
+
+if (__name__ == '__main__'):
+    sys.exit(main())

--- a/tests/api/testdata/courses_users_drop_base.json
+++ b/tests/api/testdata/courses_users_drop_base.json
@@ -1,0 +1,9 @@
+{
+    "module": "autograder.api.courses.users.drop",
+    "arguments": {
+        "target-email": "course-student@test.edulinq.org"
+    },
+    "output": {
+        "found-user": true
+    }
+}

--- a/tests/api/testdata/courses_users_drop_missing.json
+++ b/tests/api/testdata/courses_users_drop_missing.json
@@ -1,0 +1,9 @@
+{
+    "module": "autograder.api.courses.users.drop",
+    "arguments": {
+        "target-email": "ZZZ@test.edulinq.org"
+    },
+    "output": {
+        "found-user": false
+    }
+}

--- a/tests/api/testdata/courses_users_drop_not_enrolled.json
+++ b/tests/api/testdata/courses_users_drop_not_enrolled.json
@@ -1,0 +1,9 @@
+{
+    "module": "autograder.api.courses.users.drop",
+    "arguments": {
+        "target-email": "server-user@test.edulinq.org"
+    },
+    "output": {
+        "found-user": false
+    }
+}

--- a/tests/cli/testdata/courses/courses_users_drop_base.txt
+++ b/tests/cli/testdata/courses/courses_users_drop_base.txt
@@ -1,0 +1,8 @@
+{
+    "cli": "autograder.cli.courses.users.drop",
+    "arguments": [
+        "--target-email", "course-student@test.edulinq.org"
+    ]
+}
+---
+User dropped.

--- a/tests/cli/testdata/courses/courses_users_drop_missing.txt
+++ b/tests/cli/testdata/courses/courses_users_drop_missing.txt
@@ -1,0 +1,9 @@
+{
+    "cli": "autograder.cli.courses.users.drop",
+    "arguments": [
+        "--target-email", "ZZZ@test.edulinq.org"
+    ],
+    "exit-status": 1
+}
+---
+User not found.

--- a/tests/cli/testdata/courses/courses_users_drop_not_enrolled.txt
+++ b/tests/cli/testdata/courses/courses_users_drop_not_enrolled.txt
@@ -1,0 +1,9 @@
+{
+    "cli": "autograder.cli.courses.users.drop",
+    "arguments": [
+        "--target-email", "server-user@test.edulinq.org"
+    ],
+    "exit-status": 1
+}
+---
+User not found.


### PR DESCRIPTION
Add support for the new API endpoint: courses/users/drop.

This endpoint allows course admin or server admin to drop users from a course.

This PR must be reviewed with the associated server side PR, which can be found [here](https://github.com/edulinq/autograder-server/pull/99).