### PR TITLE
Added support for the users/get API endpoint.

### DIFF
--- a/autograder/api/users/get.py
+++ b/autograder/api/users/get.py
@@ -1,0 +1,23 @@
+import autograder.api.common
+import autograder.api.config
+
+API_ENDPOINT = 'users/get'
+
+API_PARAMS = [
+    autograder.api.config.PARAM_USER_EMAIL,
+    autograder.api.config.PARAM_USER_PASS,
+
+    autograder.api.config.PARAM_TARGET_EMAIL,
+]
+
+DESCRIPTION = 'Get the information for a server user.'
+
+def send(arguments, **kwargs):
+    return autograder.api.common.handle_api_request(arguments, API_PARAMS, API_ENDPOINT, **kwargs)
+
+def _get_parser():
+    parser = autograder.api.config.get_argument_parser(
+        description = DESCRIPTION,
+        params = API_PARAMS)
+
+    return parser

--- a/autograder/api/users/get.py
+++ b/autograder/api/users/get.py
@@ -7,7 +7,7 @@ API_PARAMS = [
     autograder.api.config.PARAM_USER_EMAIL,
     autograder.api.config.PARAM_USER_PASS,
 
-    autograder.api.config.PARAM_TARGET_EMAIL,
+    autograder.api.config.PARAM_TARGET_EMAIL_OR_SELF,
 ]
 
 DESCRIPTION = 'Get the information for a server user.'

--- a/autograder/cli/users/get.py
+++ b/autograder/cli/users/get.py
@@ -1,0 +1,37 @@
+import sys
+
+import autograder.api.users.get
+import autograder.cli.common
+
+def run(arguments):
+    result = autograder.api.users.get.send(arguments, exit_on_error = True)
+
+    if (not result['found']):
+        print("User not found.")
+        return 1
+
+    autograder.cli.common.list_users([result['user']], False, table = arguments.table,
+        normalize = arguments.normalize)
+    return 0
+
+def main():
+    return run(_get_parser().parse_args())
+
+def _get_parser():
+    parser = autograder.api.users.get._get_parser()
+
+    parser.add_argument('--table', dest = 'table',
+        action = 'store_true', default = False,
+        help = 'Output the results as a TSV table with a header (default: %(default)s).')
+
+    parser.add_argument('--normalize', dest = 'normalize',
+        action = 'store_true', default = False,
+        help = 'Normalize the TSV table to include at most one course enrollment per line. If the'
+            + ' user is enrolled in multiple courses, they will appear multiple times. Each line'
+            + ' contains the following columns: [email, name, role, course-id, course-name,'
+            + ' course-role]. Only applies if --table is set (default: %(default)s).')
+
+    return parser
+
+if (__name__ == '__main__'):
+    sys.exit(main())

--- a/tests/api/testdata/users_get_base.json
+++ b/tests/api/testdata/users_get_base.json
@@ -1,0 +1,18 @@
+{
+    "module": "autograder.api.users.get",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-email": "server-user@test.edulinq.org"
+    },
+    "output": {
+        "found": true,
+        "user": {
+            "type": "server",
+            "email": "server-user@test.edulinq.org",
+            "name": "server-user",
+            "role": "user",
+            "courses": {}
+        }
+    }
+}

--- a/tests/api/testdata/users_get_full.json
+++ b/tests/api/testdata/users_get_full.json
@@ -1,0 +1,44 @@
+{
+    "module": "autograder.api.users.get",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-email": "course-student@test.edulinq.org"
+    },
+    "output": {
+        "found": true,
+        "user": {
+            "type": "server",
+            "email": "course-student@test.edulinq.org",
+            "name": "course-student",
+            "role": "user",
+            "courses": {
+                "course-languages": {
+                    "id": "course-languages",
+                    "name": "Course Using Different Languages.",
+                    "role": "student"
+                },
+                "course-with-lms": {
+                    "id": "course-with-lms",
+                    "name": "Course With LMS",
+                    "role": "student"
+                },
+                "course-without-source": {
+                    "id": "course-without-source",
+                    "name": "Course Without Source",
+                    "role": "student"
+                },
+                "course101": {
+                    "id": "course101",
+                    "name": "Course 101",
+                    "role": "student"
+                },
+                "course101-with-zero-limit": {
+                    "id": "course101-with-zero-limit",
+                    "name": "Course 101 - With Zero Limit",
+                    "role": "student"
+                }
+            }
+        }
+    }
+}

--- a/tests/api/testdata/users_get_missing.json
+++ b/tests/api/testdata/users_get_missing.json
@@ -6,6 +6,7 @@
         "target-email": "ZZZ@test.edulinq.org"
     },
     "output": {
-        "found": false
+        "found": false,
+        "user": null
     }
 }

--- a/tests/api/testdata/users_get_missing.json
+++ b/tests/api/testdata/users_get_missing.json
@@ -1,0 +1,11 @@
+{
+    "module": "autograder.api.users.get",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-email": "ZZZ@test.edulinq.org"
+    },
+    "output": {
+        "found": false
+    }
+}

--- a/tests/api/testdata/users_get_self.json
+++ b/tests/api/testdata/users_get_self.json
@@ -1,0 +1,40 @@
+{
+    "module": "autograder.api.users.get",
+    "arguments": {},
+    "output": {
+        "found": true,
+        "user": {
+            "type": "server",
+            "email": "course-admin@test.edulinq.org",
+            "name": "course-admin",
+            "role": "user",
+            "courses": {
+                "course-languages": {
+                    "id": "course-languages",
+                    "name": "Course Using Different Languages.",
+                    "role": "admin"
+                },
+                "course-with-lms": {
+                    "id": "course-with-lms",
+                    "name": "Course With LMS",
+                    "role": "admin"
+                },
+                "course-without-source": {
+                    "id": "course-without-source",
+                    "name": "Course Without Source",
+                    "role": "admin"
+                },
+                "course101": {
+                    "id": "course101",
+                    "name": "Course 101",
+                    "role": "admin"
+                },
+                "course101-with-zero-limit": {
+                    "id": "course101-with-zero-limit",
+                    "name": "Course 101 - With Zero Limit",
+                    "role": "admin"
+                }
+            }
+        }
+    }
+}

--- a/tests/cli/testdata/users/users_get_base.txt
+++ b/tests/cli/testdata/users/users_get_base.txt
@@ -1,0 +1,13 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "server-user@test.edulinq.org"
+    ]
+}
+---
+Email: server-user@test.edulinq.org
+Name: server-user
+Role: user
+Courses:

--- a/tests/cli/testdata/users/users_get_base_normalize.txt
+++ b/tests/cli/testdata/users/users_get_base_normalize.txt
@@ -1,0 +1,13 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "server-user@test.edulinq.org",
+        "--table",
+        "--normalize"
+    ]
+}
+---
+email	name	role	course-id	course-name	course-role
+server-user@test.edulinq.org	server-user	user			

--- a/tests/cli/testdata/users/users_get_base_table.txt
+++ b/tests/cli/testdata/users/users_get_base_table.txt
@@ -1,0 +1,12 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "server-user@test.edulinq.org",
+        "--table"
+    ]
+}
+---
+email	name	role	courses
+server-user@test.edulinq.org	server-user	user	{}

--- a/tests/cli/testdata/users/users_get_full.txt
+++ b/tests/cli/testdata/users/users_get_full.txt
@@ -1,0 +1,32 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "course-student@test.edulinq.org"
+    ]
+}
+---
+Email: course-student@test.edulinq.org
+Name: course-student
+Role: user
+Courses:
+    ID: course-languages
+    Name: Course Using Different Languages.
+    Role: student
+
+    ID: course-with-lms
+    Name: Course With LMS
+    Role: student
+
+    ID: course-without-source
+    Name: Course Without Source
+    Role: student
+
+    ID: course101
+    Name: Course 101
+    Role: student
+
+    ID: course101-with-zero-limit
+    Name: Course 101 - With Zero Limit
+    Role: student

--- a/tests/cli/testdata/users/users_get_full_normalize.txt
+++ b/tests/cli/testdata/users/users_get_full_normalize.txt
@@ -1,0 +1,17 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "course-student@test.edulinq.org",
+        "--table",
+        "--normalize"
+    ]
+}
+---
+email	name	role	course-id	course-name	course-role
+course-student@test.edulinq.org	course-student	user	course-languages	Course Using Different Languages.	student
+course-student@test.edulinq.org	course-student	user	course-with-lms	Course With LMS	student
+course-student@test.edulinq.org	course-student	user	course-without-source	Course Without Source	student
+course-student@test.edulinq.org	course-student	user	course101	Course 101	student
+course-student@test.edulinq.org	course-student	user	course101-with-zero-limit	Course 101 - With Zero Limit	student

--- a/tests/cli/testdata/users/users_get_full_table.txt
+++ b/tests/cli/testdata/users/users_get_full_table.txt
@@ -1,0 +1,12 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "course-student@test.edulinq.org",
+        "--table"
+    ]
+}
+---
+email	name	role	courses
+course-student@test.edulinq.org	course-student	user	{'course-languages': {'id': 'course-languages', 'name': 'Course Using Different Languages.', 'role': 'student'}, 'course-with-lms': {'id': 'course-with-lms', 'name': 'Course With LMS', 'role': 'student'}, 'course-without-source': {'id': 'course-without-source', 'name': 'Course Without Source', 'role': 'student'}, 'course101': {'id': 'course101', 'name': 'Course 101', 'role': 'student'}, 'course101-with-zero-limit': {'id': 'course101-with-zero-limit', 'name': 'Course 101 - With Zero Limit', 'role': 'student'}}

--- a/tests/cli/testdata/users/users_get_missing.txt
+++ b/tests/cli/testdata/users/users_get_missing.txt
@@ -1,0 +1,11 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-email", "ZZZ@test.edulinq.org"
+    ],
+    "exit-status": 1
+}
+---
+User not found.

--- a/tests/cli/testdata/users/users_get_self.txt
+++ b/tests/cli/testdata/users/users_get_self.txt
@@ -1,0 +1,28 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": []
+}
+---
+Email: course-admin@test.edulinq.org
+Name: course-admin
+Role: user
+Courses:
+    ID: course-languages
+    Name: Course Using Different Languages.
+    Role: admin
+
+    ID: course-with-lms
+    Name: Course With LMS
+    Role: admin
+
+    ID: course-without-source
+    Name: Course Without Source
+    Role: admin
+
+    ID: course101
+    Name: Course 101
+    Role: admin
+
+    ID: course101-with-zero-limit
+    Name: Course 101 - With Zero Limit
+    Role: admin

--- a/tests/cli/testdata/users/users_get_self_normalize.txt
+++ b/tests/cli/testdata/users/users_get_self_normalize.txt
@@ -1,0 +1,14 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--table",
+        "--normalize"
+    ]
+}
+---
+email	name	role	course-id	course-name	course-role
+course-admin@test.edulinq.org	course-admin	user	course-languages	Course Using Different Languages.	admin
+course-admin@test.edulinq.org	course-admin	user	course-with-lms	Course With LMS	admin
+course-admin@test.edulinq.org	course-admin	user	course-without-source	Course Without Source	admin
+course-admin@test.edulinq.org	course-admin	user	course101	Course 101	admin
+course-admin@test.edulinq.org	course-admin	user	course101-with-zero-limit	Course 101 - With Zero Limit	admin

--- a/tests/cli/testdata/users/users_get_self_table.txt
+++ b/tests/cli/testdata/users/users_get_self_table.txt
@@ -1,0 +1,9 @@
+{
+    "cli": "autograder.cli.users.get",
+    "arguments": [
+        "--table"
+    ]
+}
+---
+email	name	role	courses
+course-admin@test.edulinq.org	course-admin	user	{'course-languages': {'id': 'course-languages', 'name': 'Course Using Different Languages.', 'role': 'admin'}, 'course-with-lms': {'id': 'course-with-lms', 'name': 'Course With LMS', 'role': 'admin'}, 'course-without-source': {'id': 'course-without-source', 'name': 'Course Without Source', 'role': 'admin'}, 'course101': {'id': 'course101', 'name': 'Course 101', 'role': 'admin'}, 'course101-with-zero-limit': {'id': 'course101-with-zero-limit', 'name': 'Course 101 - With Zero Limit', 'role': 'admin'}}


### PR DESCRIPTION
New API endpoint: users/get

This API endpoint allows people to fetch server information about themselves. Server admin or above can use the endpoint to get server information about any user.

The server side of the endpoint already exists, so no further review needed.