### PR TITLE
Added support for the users token delete API endpoint.

### DIFF
--- a/autograder/api/users/tokens/delete.py
+++ b/autograder/api/users/tokens/delete.py
@@ -1,0 +1,24 @@
+import autograder.api.common
+import autograder.api.config
+
+API_ENDPOINT = 'users/tokens/delete'
+API_PARAMS = [
+    autograder.api.config.PARAM_USER_EMAIL,
+    autograder.api.config.PARAM_USER_PASS,
+
+    autograder.api.config.APIParam('token-id',
+            'The token ID of the token to delete.',
+            required = True)
+]
+
+DESCRIPTION = 'Delete an authentication token.'
+
+def send(arguments, **kwargs):
+    return autograder.api.common.handle_api_request(arguments, API_PARAMS, API_ENDPOINT, **kwargs)
+
+def _get_parser():
+    parser = autograder.api.config.get_argument_parser(
+        description = DESCRIPTION,
+        params = API_PARAMS)
+
+    return parser

--- a/autograder/cli/users/tokens/delete.py
+++ b/autograder/cli/users/tokens/delete.py
@@ -1,0 +1,24 @@
+import sys
+
+import autograder.api.users.tokens.delete
+
+def run(arguments):
+    result = autograder.api.users.tokens.delete.send(arguments, exit_on_error = True)
+
+    if (not result['found']):
+        print("Token not found.")
+        return 1
+
+    print("Token deleted.")
+    return 0
+
+def main():
+    return run(_get_parser().parse_args())
+
+def _get_parser():
+    parser = autograder.api.users.tokens.delete._get_parser()
+
+    return parser
+
+if (__name__ == '__main__'):
+    sys.exit(main())

--- a/tests/api/testdata/users_tokens_delete_base.json
+++ b/tests/api/testdata/users_tokens_delete_base.json
@@ -1,0 +1,9 @@
+{
+    "module": "autograder.api.users.tokens.delete",
+    "arguments": {
+        "token-id": "df0a1f16-9cd8-4395-8509-10ae314fe6fc"
+    },
+    "output": {
+        "found": true
+    }
+}

--- a/tests/api/testdata/users_tokens_delete_missing.json
+++ b/tests/api/testdata/users_tokens_delete_missing.json
@@ -1,0 +1,9 @@
+{
+    "module": "autograder.api.users.tokens.delete",
+    "arguments": {
+        "token-id": "ZZZ"
+    },
+    "output": {
+        "found": false
+    }
+}

--- a/tests/cli/testdata/users/users_tokens_delete_base.txt
+++ b/tests/cli/testdata/users/users_tokens_delete_base.txt
@@ -1,0 +1,8 @@
+{
+    "cli": "autograder.cli.users.tokens.delete",
+    "arguments": [
+        "--token-id", "df0a1f16-9cd8-4395-8509-10ae314fe6fc"
+    ]
+}
+---
+Token deleted.

--- a/tests/cli/testdata/users/users_tokens_delete_missing.txt
+++ b/tests/cli/testdata/users/users_tokens_delete_missing.txt
@@ -1,0 +1,9 @@
+{
+    "cli": "autograder.cli.users.tokens.delete",
+    "arguments": [
+        "--token-id", "ZZZ"
+    ],
+    "exit-status": 1
+}
+---
+Token not found.


### PR DESCRIPTION
This PR adds support for the users/tokens/delete API endpoint.

The endpoint allows users to delete tokens on their account.

There are not any test tokens to delete, so I added them to the server test data.
This PR must be reviewed with the server side PR that allows the test cases to function, which can be found [here](https://github.com/edulinq/autograder-server/pull/107).