### PR TITLE
Fixed API endpoint typo to match the server typo update.

### DIFF
--- a/autograder/api/courses/assignments/submissions/fetch/course/attempts.py
+++ b/autograder/api/courses/assignments/submissions/fetch/course/attempts.py
@@ -1,7 +1,7 @@
 import autograder.api.common
 import autograder.api.config
 
-API_ENDPOINT = 'courses/assignments/submissions/fetch/course/attemps'
+API_ENDPOINT = 'courses/assignments/submissions/fetch/course/attempts'
 API_PARAMS = [
     autograder.api.config.PARAM_COURSE_ID,
     autograder.api.config.PARAM_USER_EMAIL,


### PR DESCRIPTION
This PR fixes a typo in the name of `courses/assignments/submissions/fetch/course/attempts`.

The corresponding server side change updates the typo, which can be found [here](https://github.com/edulinq/autograder-server/pull/111). These PRs must be reviewed together.