### PR TITLE
Updated scored question testdata to include hard fail and skipped fields.

### DIFF
--- a/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_course_attempts_base.json
+++ b/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_course_attempts_base.json
@@ -25,6 +25,8 @@
                             "name": "Q1",
                             "max_points": 1,
                             "score": 1,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000
@@ -33,6 +35,8 @@
                             "name": "Q2",
                             "max_points": 1,
                             "score": 1,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000
@@ -41,6 +45,8 @@
                             "name": "Style",
                             "max_points": 0,
                             "score": 0,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "Style is clean!",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000

--- a/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_course_attempts_student.json
+++ b/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_course_attempts_student.json
@@ -21,6 +21,8 @@
                             "name": "Q1",
                             "max_points": 1,
                             "score": 1,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000
@@ -29,6 +31,8 @@
                             "name": "Q2",
                             "max_points": 1,
                             "score": 1,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000
@@ -37,6 +41,8 @@
                             "name": "Style",
                             "max_points": 0,
                             "score": 0,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "Style is clean!",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000

--- a/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_attempt_other_recent.json
+++ b/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_attempt_other_recent.json
@@ -22,6 +22,8 @@
                         "name": "Q1",
                         "max_points": 1,
                         "score": 1,
+                        "hard_fail": false,
+                        "skipped": false,
                         "message": "",
                         "grading_start_time": 1697406273000,
                         "grading_end_time": 1697406273000
@@ -30,6 +32,8 @@
                         "name": "Q2",
                         "max_points": 1,
                         "score": 1,
+                        "hard_fail": false,
+                        "skipped": false,
                         "message": "",
                         "grading_start_time": 1697406273000,
                         "grading_end_time": 1697406273000
@@ -38,6 +42,8 @@
                         "name": "Style",
                         "max_points": 0,
                         "score": 0,
+                        "hard_fail": false,
+                        "skipped": false,
                         "message": "Style is clean!",
                         "grading_start_time": 1697406273000,
                         "grading_end_time": 1697406273000

--- a/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_attempt_other_specific.json
+++ b/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_attempt_other_specific.json
@@ -23,6 +23,8 @@
                         "name": "Q1",
                         "max_points": 1,
                         "score": 1,
+                        "hard_fail": false,
+                        "skipped": false,
                         "message": "",
                         "grading_start_time": 1697406266000,
                         "grading_end_time": 1697406266000
@@ -31,6 +33,8 @@
                         "name": "Q2",
                         "max_points": 1,
                         "score": 0,
+                        "hard_fail": false,
+                        "skipped": false,
                         "message": "NotImplemented returned.",
                         "grading_start_time": 1697406266000,
                         "grading_end_time": 1697406266000
@@ -39,6 +43,8 @@
                         "name": "Style",
                         "max_points": 0,
                         "score": 0,
+                        "hard_fail": false,
+                        "skipped": false,
                         "message": "Style is clean!",
                         "grading_start_time": 1697406266000,
                         "grading_end_time": 1697406266000

--- a/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_attempts_other_nonempty.json
+++ b/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_attempts_other_nonempty.json
@@ -22,6 +22,8 @@
                             "name": "Q1",
                             "max_points": 1,
                             "score": 0,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "NotImplemented returned.",
                             "grading_start_time": 1697406256000,
                             "grading_end_time": 1697406256000
@@ -30,6 +32,8 @@
                             "name": "Q2",
                             "max_points": 1,
                             "score": 0,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "NotImplemented returned.",
                             "grading_start_time": 1697406256000,
                             "grading_end_time": 1697406256000
@@ -38,6 +42,8 @@
                             "name": "Style",
                             "max_points": 0,
                             "score": 0,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "Style is clean!",
                             "grading_start_time": 1697406256000,
                             "grading_end_time": 1697406256000
@@ -72,6 +78,8 @@
                             "name": "Q1",
                             "max_points": 1,
                             "score": 1,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "",
                             "grading_start_time": 1697406266000,
                             "grading_end_time": 1697406266000
@@ -80,6 +88,8 @@
                             "name": "Q2",
                             "max_points": 1,
                             "score": 0,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "NotImplemented returned.",
                             "grading_start_time": 1697406266000,
                             "grading_end_time": 1697406266000
@@ -88,6 +98,8 @@
                             "name": "Style",
                             "max_points": 0,
                             "score": 0,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "Style is clean!",
                             "grading_start_time": 1697406266000,
                             "grading_end_time": 1697406266000
@@ -122,6 +134,8 @@
                             "name": "Q1",
                             "max_points": 1,
                             "score": 1,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000
@@ -130,6 +144,8 @@
                             "name": "Q2",
                             "max_points": 1,
                             "score": 1,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000
@@ -138,6 +154,8 @@
                             "name": "Style",
                             "max_points": 0,
                             "score": 0,
+                            "hard_fail": false,
+                            "skipped": false,
                             "message": "Style is clean!",
                             "grading_start_time": 1697406273000,
                             "grading_end_time": 1697406273000

--- a/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_peek_other_recent.json
+++ b/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_peek_other_recent.json
@@ -21,6 +21,8 @@
                     "name": "Q1",
                     "max_points": 1,
                     "score": 1,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "",
                     "grading_start_time": 1697406273000,
                     "grading_end_time": 1697406273000
@@ -29,6 +31,8 @@
                     "name": "Q2",
                     "max_points": 1,
                     "score": 1,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "",
                     "grading_start_time": 1697406273000,
                     "grading_end_time": 1697406273000
@@ -37,6 +41,8 @@
                     "name": "Style",
                     "max_points": 0,
                     "score": 0,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "Style is clean!",
                     "grading_start_time": 1697406273000,
                     "grading_end_time": 1697406273000

--- a/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_peek_other_specific.json
+++ b/tests/api/testdata/courses/assignments/fetch/courses_assignments_submissions_fetch_user_peek_other_specific.json
@@ -22,6 +22,8 @@
                     "name": "Q1",
                     "max_points": 1,
                     "score": 1,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "",
                     "grading_start_time": 1697406266000,
                     "grading_end_time": 1697406266000
@@ -30,6 +32,8 @@
                     "name": "Q2",
                     "max_points": 1,
                     "score": 0,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "NotImplemented returned.",
                     "grading_start_time": 1697406266000,
                     "grading_end_time": 1697406266000
@@ -38,6 +42,8 @@
                     "name": "Style",
                     "max_points": 0,
                     "score": 0,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "Style is clean!",
                     "grading_start_time": 1697406266000,
                     "grading_end_time": 1697406266000

--- a/tests/api/testdata/courses/assignments/submit/courses_assignments_submissions_submit_base.json
+++ b/tests/api/testdata/courses/assignments/submit/courses_assignments_submissions_submit_base.json
@@ -27,6 +27,8 @@
                     "name": "Q1",
                     "max_points": 1,
                     "score": 1,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "",
                     "grading_start_time": 1234567890123,
                     "grading_end_time": 1234567890123
@@ -35,6 +37,8 @@
                     "name": "Q2",
                     "max_points": 1,
                     "score": 1,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "",
                     "grading_start_time": 1234567890123,
                     "grading_end_time": 1234567890123
@@ -43,6 +47,8 @@
                     "name": "Style",
                     "max_points": 0,
                     "score": 0,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "Style is clean!",
                     "grading_start_time": 1234567890123,
                     "grading_end_time": 1234567890123

--- a/tests/api/testdata/courses/assignments/submit/courses_assignments_submissions_submit_epoch_allow.json
+++ b/tests/api/testdata/courses/assignments/submit/courses_assignments_submissions_submit_epoch_allow.json
@@ -29,6 +29,8 @@
                     "name": "Task 1: add()",
                     "max_points": 10,
                     "score": 10,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "",
                     "grading_start_time": 1234567890123,
                     "grading_end_time": 1234567890123

--- a/tests/api/testdata/courses/assignments/submit/courses_assignments_submissions_submit_no_compile.json
+++ b/tests/api/testdata/courses/assignments/submit/courses_assignments_submissions_submit_no_compile.json
@@ -27,6 +27,8 @@
                     "name": "Q1",
                     "max_points": 1,
                     "score": 0,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "Submission could not be graded.",
                     "grading_start_time": 1234567890123,
                     "grading_end_time": 1234567890123
@@ -35,6 +37,8 @@
                     "name": "Q2",
                     "max_points": 1,
                     "score": 0,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "Submission could not be graded.",
                     "grading_start_time": 1234567890123,
                     "grading_end_time": 1234567890123
@@ -43,6 +47,8 @@
                     "name": "Style",
                     "max_points": 0,
                     "score": 0,
+                    "hard_fail": false,
+                    "skipped": false,
                     "message": "Submission could not be graded.",
                     "grading_start_time": 1234567890123,
                     "grading_end_time": 1234567890123


### PR DESCRIPTION
This PR updates the relevant testdata to include the new `hard_fail` and `skipped` fields that were added to `autograder-server` by [this commit](https://github.com/edulinq/autograder-server/commit/5851f7cc3e66971e616bd3e90d476398cc4c01de).