### PR TITLE
Updated analysis and heartbeat testdata for the new server version.

### DIFF
--- a/.ci/backend.py
+++ b/.ci/backend.py
@@ -17,7 +17,7 @@ import util
 DEFAULT_PORT = 8080
 WEB_URL = 'http://127.0.0.1'
 
-DEFAULT_DOCKER_IMAGE = 'ghcr.io/edulinq/autograder-server:3.5.0-prebuilt'
+DEFAULT_DOCKER_IMAGE = 'ghcr.io/edulinq/autograder-server:3.5.1-prebuilt'
 DOCKER_CONTAINER_NAME = 'autograder-py-verify-test-data'
 DOCKER_START_SLEEP_TIME_SECS = 0.25
 DOCKER_STOP_WAIT_TIME_SECS = 1

--- a/autograder/api/config.py
+++ b/autograder/api/config.py
@@ -293,8 +293,8 @@ PARAM_NEW_PASS = APIParam('new-pass',
     'The new password to set for the user that is the target of this request.',
     required = True, hash = True)
 
-PARAM_OVERWRITE_CACHE = APIParam('overwrite-cache',
-    ('Replace any existing cache entries that match the current operation'
+PARAM_OVERWRITE_RECORDS = APIParam('overwrite-records',
+    ('Replace any existing records that match the current operation'
         + ' (e.g. re-do existing results).'),
     required = False,
     parser_options = {'action': 'store_true', 'default': False})

--- a/autograder/api/courses/assignments/submissions/analysis/individual.py
+++ b/autograder/api/courses/assignments/submissions/analysis/individual.py
@@ -7,7 +7,7 @@ API_PARAMS = [
     autograder.api.config.PARAM_USER_PASS,
 
     autograder.api.config.PARAM_DRY_RUN,
-    autograder.api.config.PARAM_OVERWRITE_CACHE,
+    autograder.api.config.PARAM_OVERWRITE_RECORDS,
     autograder.api.config.PARAM_SUBMISSION_SPECS,
     autograder.api.config.PARAM_WAIT_FOR_COMPLETION,
 ]

--- a/autograder/api/courses/assignments/submissions/analysis/pairwise.py
+++ b/autograder/api/courses/assignments/submissions/analysis/pairwise.py
@@ -7,7 +7,7 @@ API_PARAMS = [
     autograder.api.config.PARAM_USER_PASS,
 
     autograder.api.config.PARAM_DRY_RUN,
-    autograder.api.config.PARAM_OVERWRITE_CACHE,
+    autograder.api.config.PARAM_OVERWRITE_RECORDS,
     autograder.api.config.PARAM_SUBMISSION_SPECS,
     autograder.api.config.PARAM_WAIT_FOR_COMPLETION,
 ]

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_base.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_base.json
@@ -7,14 +7,14 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": false,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "wait-for-completion": false
     },
     "output": {
         "complete": false,
         "options": {
             "dry-run": false,
-            "overwrite-cache": false,
+            "overwrite-records": false,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -25,6 +25,7 @@
             "complete": false,
             "complete-count": 0,
             "pending-count": 2,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 0,
             "last-timestamp": 0,
@@ -79,6 +80,7 @@
                 "max": 0
             }
         },
-        "results": {}
+        "results": {},
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun.json
@@ -6,14 +6,14 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": true,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "wait-for-completion": false
     },
     "output": {
         "complete": false,
         "options": {
             "dry-run": true,
-            "overwrite-cache": false,
+            "overwrite-records": false,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -24,6 +24,7 @@
             "complete": false,
             "complete-count": 0,
             "pending-count": 2,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 0,
             "last-timestamp": 0,
@@ -78,6 +79,7 @@
                 "max": 0
             }
         },
-        "results": {}
+        "results": {},
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_overwritecache.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_overwritecache.json
@@ -6,14 +6,14 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": true,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "wait-for-completion": false
     },
     "output": {
         "complete": false,
         "options": {
             "dry-run": true,
-            "overwrite-cache": true,
+            "overwrite-records": true,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -24,6 +24,7 @@
             "complete": false,
             "complete-count": 0,
             "pending-count": 2,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 0,
             "last-timestamp": 0,
@@ -78,6 +79,7 @@
                 "max": 0
             }
         },
-        "results": {}
+        "results": {},
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_overwritecache_wait.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_overwritecache_wait.json
@@ -6,7 +6,7 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": true,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "wait-for-completion": true
     },
     "output-modifier": "clean_output_timestamps",
@@ -14,7 +14,7 @@
         "complete": true,
         "options": {
             "dry-run": true,
-            "overwrite-cache": true,
+            "overwrite-records": true,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -25,6 +25,7 @@
             "complete": true,
             "complete-count": 2,
             "pending-count": 0,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 1234567890123,
             "last-timestamp": 1234567890123,
@@ -146,6 +147,7 @@
                 "score-delta": 1,
                 "score-per-hour": 360
             }
-        }
+        },
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_wait.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_wait.json
@@ -6,7 +6,7 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": true,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "wait-for-completion": true
     },
     "output-modifier": "clean_output_timestamps",
@@ -14,7 +14,7 @@
         "complete": true,
         "options": {
             "dry-run": true,
-            "overwrite-cache": false,
+            "overwrite-records": false,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -25,6 +25,7 @@
             "complete": true,
             "complete-count": 2,
             "pending-count": 0,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 1234567890123,
             "last-timestamp": 1234567890123,
@@ -146,6 +147,7 @@
                 "score-delta": 1,
                 "score-per-hour": 360
             }
-        }
+        },
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_overwritecache.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_overwritecache.json
@@ -7,14 +7,14 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": false,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "wait-for-completion": false
     },
     "output": {
         "complete": false,
         "options": {
             "dry-run": false,
-            "overwrite-cache": true,
+            "overwrite-records": true,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -25,6 +25,7 @@
             "complete": false,
             "complete-count": 0,
             "pending-count": 2,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 0,
             "last-timestamp": 0,
@@ -79,6 +80,7 @@
                 "max": 0
             }
         },
-        "results": {}
+        "results": {},
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_overwritecache_wait.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_overwritecache_wait.json
@@ -7,7 +7,7 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": false,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "wait-for-completion": true
     },
     "output-modifier": "clean_output_timestamps",
@@ -15,7 +15,7 @@
         "complete": true,
         "options": {
             "dry-run": false,
-            "overwrite-cache": true,
+            "overwrite-records": true,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -26,6 +26,7 @@
             "complete": true,
             "complete-count": 2,
             "pending-count": 0,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 1234567890123,
             "last-timestamp": 1234567890123,
@@ -147,6 +148,7 @@
                 "score-delta": 1,
                 "score-per-hour": 360
             }
-        }
+        },
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_wait.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_wait.json
@@ -7,7 +7,7 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": false,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "wait-for-completion": true
     },
     "output-modifier": "clean_output_timestamps",
@@ -15,7 +15,7 @@
         "complete": true,
         "options": {
             "dry-run": false,
-            "overwrite-cache": false,
+            "overwrite-records": false,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -26,6 +26,7 @@
             "complete": true,
             "complete-count": 2,
             "pending-count": 0,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 1234567890123,
             "last-timestamp": 1234567890123,
@@ -147,6 +148,7 @@
                 "score-delta": 1,
                 "score-per-hour": 360
             }
-        }
+        },
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_base.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_base.json
@@ -7,14 +7,14 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": false,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "wait-for-completion": false
     },
     "output": {
         "complete": false,
         "options": {
             "dry-run": false,
-            "overwrite-cache": false,
+            "overwrite-records": false,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -25,6 +25,7 @@
             "complete": false,
             "complete-count": 0,
             "pending-count": 1,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 0,
             "last-timestamp": 0,
@@ -37,6 +38,7 @@
                 "max": 0
             }
         },
-        "results": {}
+        "results": {},
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun.json
@@ -7,14 +7,14 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": true,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "wait-for-completion": false
     },
     "output": {
         "complete": false,
         "options": {
             "dry-run": true,
-            "overwrite-cache": false,
+            "overwrite-records": false,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -25,6 +25,7 @@
             "complete": false,
             "complete-count": 0,
             "pending-count": 1,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 0,
             "last-timestamp": 0,
@@ -37,6 +38,7 @@
                 "max": 0
             }
         },
-        "results": {}
+        "results": {},
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_overwritecache.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_overwritecache.json
@@ -6,14 +6,14 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": true,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "wait-for-completion": false
     },
     "output": {
         "complete": false,
         "options": {
             "dry-run": true,
-            "overwrite-cache": true,
+            "overwrite-records": true,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -24,6 +24,7 @@
             "complete": false,
             "complete-count": 0,
             "pending-count": 1,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 0,
             "last-timestamp": 0,
@@ -36,6 +37,7 @@
                 "max": 0
             }
         },
-        "results": {}
+        "results": {},
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_overwritecache_wait.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_overwritecache_wait.json
@@ -7,7 +7,7 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": true,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "wait-for-completion": true
     },
     "output-modifier": "clean_output_timestamps",
@@ -15,7 +15,7 @@
         "complete": true,
         "options": {
             "dry-run": true,
-            "overwrite-cache": true,
+            "overwrite-records": true,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -26,6 +26,7 @@
             "complete": true,
             "complete-count": 1,
             "pending-count": 0,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 1234567890123,
             "last-timestamp": 1234567890123,
@@ -76,6 +77,7 @@
                 },
                 "total-mean-similarity": 0.13
             }
-        }
+        },
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_wait.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_wait.json
@@ -7,7 +7,7 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": true,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "wait-for-completion": true
     },
     "output-modifier": "clean_output_timestamps",
@@ -15,7 +15,7 @@
         "complete": true,
         "options": {
             "dry-run": true,
-            "overwrite-cache": false,
+            "overwrite-records": false,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -26,6 +26,7 @@
             "complete": true,
             "complete-count": 1,
             "pending-count": 0,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 1234567890123,
             "last-timestamp": 1234567890123,
@@ -76,6 +77,7 @@
                 },
                 "total-mean-similarity": 0.13
             }
-        }
+        },
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_overwritecache.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_overwritecache.json
@@ -7,14 +7,14 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": false,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "wait-for-completion": false
     },
     "output": {
         "complete": false,
         "options": {
             "dry-run": false,
-            "overwrite-cache": true,
+            "overwrite-records": true,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -25,6 +25,7 @@
             "complete": false,
             "complete-count": 0,
             "pending-count": 1,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 0,
             "last-timestamp": 0,
@@ -37,6 +38,7 @@
                 "max": 0
             }
         },
-        "results": {}
+        "results": {},
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_overwritecache_wait.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_overwritecache_wait.json
@@ -7,7 +7,7 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": false,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "wait-for-completion": true
     },
     "output-modifier": "clean_output_timestamps",
@@ -15,7 +15,7 @@
         "complete": true,
         "options": {
             "dry-run": false,
-            "overwrite-cache": true,
+            "overwrite-records": true,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -26,6 +26,7 @@
             "complete": true,
             "complete-count": 1,
             "pending-count": 0,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 1234567890123,
             "last-timestamp": 1234567890123,
@@ -76,6 +77,7 @@
                 },
                 "total-mean-similarity": 0.13
             }
-        }
+        },
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_wait.json
+++ b/tests/api/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_wait.json
@@ -7,7 +7,7 @@
             "course101::hw0::course-student@test.edulinq.org::1697406265"
         ],
         "dry-run": false,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "wait-for-completion": true
     },
     "output-modifier": "clean_output_timestamps",
@@ -15,7 +15,7 @@
         "complete": true,
         "options": {
             "dry-run": false,
-            "overwrite-cache": false,
+            "overwrite-records": false,
             "submissions": [
                 "course101::hw0::course-student@test.edulinq.org::1697406256",
                 "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -26,6 +26,7 @@
             "complete": true,
             "complete-count": 1,
             "pending-count": 0,
+            "error-count": 0,
             "failure-count": 0,
             "first-timestamp": 1234567890123,
             "last-timestamp": 1234567890123,
@@ -76,6 +77,7 @@
                 },
                 "total-mean-similarity": 0.13
             }
-        }
+        },
+        "work-errors": {}
     }
 }

--- a/tests/api/testdata/metadata/metadata_describe_base.json
+++ b/tests/api/testdata/metadata/metadata_describe_base.json
@@ -145,7 +145,7 @@
                         "type": "bool"
                     },
                     {
-                        "name": "overwrite-cache",
+                        "name": "overwrite-records",
                         "type": "bool"
                     },
                     {
@@ -181,6 +181,10 @@
                     {
                         "name": "summary",
                         "type": "*model.IndividualAnalysisSummary"
+                    },
+                    {
+                        "name": "work-errors",
+                        "type": "map[string]string"
                     }
                 ]
             },
@@ -192,7 +196,7 @@
                         "type": "bool"
                     },
                     {
-                        "name": "overwrite-cache",
+                        "name": "overwrite-records",
                         "type": "bool"
                     },
                     {
@@ -228,6 +232,10 @@
                     {
                         "name": "summary",
                         "type": "*model.PairwiseAnalysisSummary"
+                    },
+                    {
+                        "name": "work-errors",
+                        "type": "map[string]string"
                     }
                 ]
             },
@@ -1383,7 +1391,7 @@
                         "type": "bool"
                     },
                     {
-                        "name": "overwrite-cache",
+                        "name": "overwrite-records",
                         "type": "bool"
                     },
                     {
@@ -1921,6 +1929,10 @@
                         "type": "int"
                     },
                     {
+                        "name": "error-count",
+                        "type": "int"
+                    },
+                    {
                         "name": "failure-count",
                         "type": "int"
                     },
@@ -2442,6 +2454,10 @@
                         "type": "int"
                     },
                     {
+                        "name": "error-count",
+                        "type": "int"
+                    },
+                    {
                         "name": "failure-count",
                         "type": "int"
                     },
@@ -2538,6 +2554,10 @@
                     },
                     {
                         "name": "complete-count",
+                        "type": "int"
+                    },
+                    {
+                        "name": "error-count",
                         "type": "int"
                     },
                     {

--- a/tests/api/testdata/metadata/metadata_describe_base.json
+++ b/tests/api/testdata/metadata/metadata_describe_base.json
@@ -1097,6 +1097,16 @@
                     }
                 ]
             },
+            "metadata/heartbeat": {
+                "description": "Get server heartbeat.",
+                "input": [],
+                "output": [
+                    {
+                        "name": "server-version",
+                        "type": "util.Version"
+                    }
+                ]
+            },
             "stats/query": {
                 "description": "Query stats for the server.",
                 "input": [
@@ -1826,6 +1836,24 @@
                     {
                         "name": "to",
                         "type": "[]string"
+                    }
+                ]
+            },
+            "jobmanager.JobOptions": {
+                "category": "struct",
+                "description": "The user level options for a job, including an optional context.",
+                "fields": [
+                    {
+                        "name": "dry-run",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "overwrite-records",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "wait-for-completion",
+                        "type": "bool"
                     }
                 ]
             },
@@ -2955,6 +2983,23 @@
             "util.FileSpecType": {
                 "category": "alias",
                 "alias-type": "string"
+            },
+            "util.Version": {
+                "category": "struct",
+                "fields": [
+                    {
+                        "name": "base-version",
+                        "type": "string"
+                    },
+                    {
+                        "name": "git-hash",
+                        "type": "string"
+                    },
+                    {
+                        "name": "is-dirty",
+                        "type": "bool"
+                    }
+                ]
             }
         }
     }

--- a/tests/api/testdata/metadata/metadata_describe_force.json
+++ b/tests/api/testdata/metadata/metadata_describe_force.json
@@ -145,7 +145,7 @@
                         "type": "bool"
                     },
                     {
-                        "name": "overwrite-cache",
+                        "name": "overwrite-records",
                         "type": "bool"
                     },
                     {
@@ -181,6 +181,10 @@
                     {
                         "name": "summary",
                         "type": "*model.IndividualAnalysisSummary"
+                    },
+                    {
+                        "name": "work-errors",
+                        "type": "map[string]string"
                     }
                 ]
             },
@@ -192,7 +196,7 @@
                         "type": "bool"
                     },
                     {
-                        "name": "overwrite-cache",
+                        "name": "overwrite-records",
                         "type": "bool"
                     },
                     {
@@ -210,6 +214,10 @@
                     {
                         "name": "wait-for-completion",
                         "type": "bool"
+                    },
+                    {
+                        "name": "work-errors",
+                        "type": "map[string]string"
                     }
                 ],
                 "output": [
@@ -1383,7 +1391,7 @@
                         "type": "bool"
                     },
                     {
-                        "name": "overwrite-cache",
+                        "name": "overwrite-records",
                         "type": "bool"
                     },
                     {
@@ -1921,6 +1929,10 @@
                         "type": "int"
                     },
                     {
+                        "name": "error-count",
+                        "type": "int"
+                    },
+                    {
                         "name": "failure-count",
                         "type": "int"
                     },
@@ -2442,6 +2454,10 @@
                         "type": "int"
                     },
                     {
+                        "name": "error-count",
+                        "type": "int"
+                    },
+                    {
                         "name": "failure-count",
                         "type": "int"
                     },
@@ -2538,6 +2554,10 @@
                     },
                     {
                         "name": "complete-count",
+                        "type": "int"
+                    },
+                    {
+                        "name": "error-count",
                         "type": "int"
                     },
                     {

--- a/tests/api/testdata/metadata/metadata_describe_force.json
+++ b/tests/api/testdata/metadata/metadata_describe_force.json
@@ -214,10 +214,6 @@
                     {
                         "name": "wait-for-completion",
                         "type": "bool"
-                    },
-                    {
-                        "name": "work-errors",
-                        "type": "map[string]string"
                     }
                 ],
                 "output": [
@@ -236,6 +232,10 @@
                     {
                         "name": "summary",
                         "type": "*model.PairwiseAnalysisSummary"
+                    },
+                    {
+                        "name": "work-errors",
+                        "type": "map[string]string"
                     }
                 ]
             },
@@ -1097,6 +1097,16 @@
                     }
                 ]
             },
+            "metadata/heartbeat": {
+                "description": "Get server heartbeat.",
+                "input": [],
+                "output": [
+                    {
+                        "name": "server-version",
+                        "type": "util.Version"
+                    }
+                ]
+            },
             "stats/query": {
                 "description": "Query stats for the server.",
                 "input": [
@@ -1826,6 +1836,24 @@
                     {
                         "name": "to",
                         "type": "[]string"
+                    }
+                ]
+            },
+            "jobmanager.JobOptions": {
+                "category": "struct",
+                "description": "The user level options for a job, including an optional context.",
+                "fields": [
+                    {
+                        "name": "dry-run",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "overwrite-records",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "wait-for-completion",
+                        "type": "bool"
                     }
                 ]
             },
@@ -2955,6 +2983,23 @@
             "util.FileSpecType": {
                 "category": "alias",
                 "alias-type": "string"
+            },
+            "util.Version": {
+                "category": "struct",
+                "fields": [
+                    {
+                        "name": "base-version",
+                        "type": "string"
+                    },
+                    {
+                        "name": "git-hash",
+                        "type": "string"
+                    },
+                    {
+                        "name": "is-dirty",
+                        "type": "bool"
+                    }
+                ]
             }
         }
     }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_base.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_base.txt
@@ -10,7 +10,7 @@
     "complete": false,
     "options": {
         "dry-run": false,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -21,6 +21,7 @@
         "complete": false,
         "complete-count": 0,
         "pending-count": 2,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 0,
         "last-timestamp": 0,
@@ -75,5 +76,6 @@
             "max": 0
         }
     },
-    "results": {}
+    "results": {},
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun.txt
@@ -11,7 +11,7 @@
     "complete": false,
     "options": {
         "dry-run": true,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -22,6 +22,7 @@
         "complete": false,
         "complete-count": 0,
         "pending-count": 2,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 0,
         "last-timestamp": 0,
@@ -76,5 +77,6 @@
             "max": 0
         }
     },
-    "results": {}
+    "results": {},
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_overwritecache.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_overwritecache.txt
@@ -2,7 +2,7 @@
     "cli": "autograder.cli.courses.assignments.submissions.analysis.individual",
     "arguments": [
         "--dry-run",
-        "--overwrite-cache",
+        "--overwrite-records",
         "course101::hw0::course-student@test.edulinq.org::1697406256",
         "course101::hw0::course-student@test.edulinq.org::1697406265"
     ]
@@ -12,7 +12,7 @@
     "complete": false,
     "options": {
         "dry-run": true,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -23,6 +23,7 @@
         "complete": false,
         "complete-count": 0,
         "pending-count": 2,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 0,
         "last-timestamp": 0,
@@ -77,5 +78,6 @@
             "max": 0
         }
     },
-    "results": {}
+    "results": {},
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_overwritecache_wait.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_overwritecache_wait.txt
@@ -2,7 +2,7 @@
     "cli": "autograder.cli.courses.assignments.submissions.analysis.individual",
     "arguments": [
         "--dry-run",
-        "--overwrite-cache",
+        "--overwrite-records",
         "--wait-for-completion",
         "course101::hw0::course-student@test.edulinq.org::1697406256",
         "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -13,7 +13,7 @@
     "complete": true,
     "options": {
         "dry-run": true,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -24,6 +24,7 @@
         "complete": true,
         "complete-count": 2,
         "pending-count": 0,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 1234567890123,
         "last-timestamp": 1234567890123,
@@ -145,5 +146,6 @@
             "score-delta": 1,
             "score-per-hour": 360
         }
-    }
+    },
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_wait.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_dryrun_wait.txt
@@ -12,7 +12,7 @@
     "complete": true,
     "options": {
         "dry-run": true,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -23,6 +23,7 @@
         "complete": true,
         "complete-count": 2,
         "pending-count": 0,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 1234567890123,
         "last-timestamp": 1234567890123,
@@ -144,5 +145,6 @@
             "score-delta": 1,
             "score-per-hour": 360
         }
-    }
+    },
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_overwritecache.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_overwritecache.txt
@@ -1,7 +1,7 @@
 {
     "cli": "autograder.cli.courses.assignments.submissions.analysis.individual",
     "arguments": [
-        "--overwrite-cache",
+        "--overwrite-records",
         "course101::hw0::course-student@test.edulinq.org::1697406256",
         "course101::hw0::course-student@test.edulinq.org::1697406265"
     ]
@@ -11,7 +11,7 @@
     "complete": false,
     "options": {
         "dry-run": false,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -22,6 +22,7 @@
         "complete": false,
         "complete-count": 0,
         "pending-count": 2,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 0,
         "last-timestamp": 0,
@@ -76,5 +77,6 @@
             "max": 0
         }
     },
-    "results": {}
+    "results": {},
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_overwritecache_wait.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_overwritecache_wait.txt
@@ -1,7 +1,7 @@
 {
     "cli": "autograder.cli.courses.assignments.submissions.analysis.individual",
     "arguments": [
-        "--overwrite-cache",
+        "--overwrite-records",
         "--wait-for-completion",
         "course101::hw0::course-student@test.edulinq.org::1697406256",
         "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -12,7 +12,7 @@
     "complete": true,
     "options": {
         "dry-run": false,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -23,6 +23,7 @@
         "complete": true,
         "complete-count": 2,
         "pending-count": 0,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 1234567890123,
         "last-timestamp": 1234567890123,
@@ -144,5 +145,6 @@
             "score-delta": 1,
             "score-per-hour": 360
         }
-    }
+    },
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_wait.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_individual_wait.txt
@@ -11,7 +11,7 @@
     "complete": true,
     "options": {
         "dry-run": false,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -22,6 +22,7 @@
         "complete": true,
         "complete-count": 2,
         "pending-count": 0,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 1234567890123,
         "last-timestamp": 1234567890123,
@@ -143,5 +144,6 @@
             "score-delta": 1,
             "score-per-hour": 360
         }
-    }
+    },
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_base.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_base.txt
@@ -10,7 +10,7 @@
     "complete": false,
     "options": {
         "dry-run": false,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -21,6 +21,7 @@
         "complete": false,
         "complete-count": 0,
         "pending-count": 1,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 0,
         "last-timestamp": 0,
@@ -33,5 +34,6 @@
             "max": 0
         }
     },
-    "results": {}
+    "results": {},
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun.txt
@@ -11,7 +11,7 @@
     "complete": false,
     "options": {
         "dry-run": true,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -22,6 +22,7 @@
         "complete": false,
         "complete-count": 0,
         "pending-count": 1,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 0,
         "last-timestamp": 0,
@@ -34,5 +35,6 @@
             "max": 0
         }
     },
-    "results": {}
+    "results": {},
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_overwritecache.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_overwritecache.txt
@@ -2,7 +2,7 @@
     "cli": "autograder.cli.courses.assignments.submissions.analysis.pairwise",
     "arguments": [
         "--dry-run",
-        "--overwrite-cache",
+        "--overwrite-records",
         "course101::hw0::course-student@test.edulinq.org::1697406256",
         "course101::hw0::course-student@test.edulinq.org::1697406265"
     ]
@@ -12,7 +12,7 @@
     "complete": false,
     "options": {
         "dry-run": true,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -23,6 +23,7 @@
         "complete": false,
         "complete-count": 0,
         "pending-count": 1,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 0,
         "last-timestamp": 0,
@@ -35,5 +36,6 @@
             "max": 0
         }
     },
-    "results": {}
+    "results": {},
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_overwritecache_wait.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_overwritecache_wait.txt
@@ -2,7 +2,7 @@
     "cli": "autograder.cli.courses.assignments.submissions.analysis.pairwise",
     "arguments": [
         "--dry-run",
-        "--overwrite-cache",
+        "--overwrite-records",
         "--wait-for-completion",
         "course101::hw0::course-student@test.edulinq.org::1697406256",
         "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -13,7 +13,7 @@
     "complete": true,
     "options": {
         "dry-run": true,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -24,6 +24,7 @@
         "complete": true,
         "complete-count": 1,
         "pending-count": 0,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 1234567890123,
         "last-timestamp": 1234567890123,
@@ -74,5 +75,6 @@
             },
             "total-mean-similarity": 0.13
         }
-    }
+    },
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_wait.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_dryrun_wait.txt
@@ -12,7 +12,7 @@
     "complete": true,
     "options": {
         "dry-run": true,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -23,6 +23,7 @@
         "complete": true,
         "complete-count": 1,
         "pending-count": 0,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 1234567890123,
         "last-timestamp": 1234567890123,
@@ -73,5 +74,6 @@
             },
             "total-mean-similarity": 0.13
         }
-    }
+    },
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_overwritecache.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_overwritecache.txt
@@ -1,7 +1,7 @@
 {
     "cli": "autograder.cli.courses.assignments.submissions.analysis.pairwise",
     "arguments": [
-        "--overwrite-cache",
+        "--overwrite-records",
         "course101::hw0::course-student@test.edulinq.org::1697406256",
         "course101::hw0::course-student@test.edulinq.org::1697406265"
     ]
@@ -11,7 +11,7 @@
     "complete": false,
     "options": {
         "dry-run": false,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -22,6 +22,7 @@
         "complete": false,
         "complete-count": 0,
         "pending-count": 1,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 0,
         "last-timestamp": 0,
@@ -34,5 +35,6 @@
             "max": 0
         }
     },
-    "results": {}
+    "results": {},
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_overwritecache_wait.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_overwritecache_wait.txt
@@ -1,7 +1,7 @@
 {
     "cli": "autograder.cli.courses.assignments.submissions.analysis.pairwise",
     "arguments": [
-        "--overwrite-cache",
+        "--overwrite-records",
         "--wait-for-completion",
         "course101::hw0::course-student@test.edulinq.org::1697406256",
         "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -12,7 +12,7 @@
     "complete": true,
     "options": {
         "dry-run": false,
-        "overwrite-cache": true,
+        "overwrite-records": true,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -23,6 +23,7 @@
         "complete": true,
         "complete-count": 1,
         "pending-count": 0,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 1234567890123,
         "last-timestamp": 1234567890123,
@@ -73,5 +74,6 @@
             },
             "total-mean-similarity": 0.13
         }
-    }
+    },
+    "work-errors": {}
 }

--- a/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_wait.txt
+++ b/tests/cli/testdata/courses/assignments/analysis/courses_assignments_submissions_analysis_pairwise_wait.txt
@@ -11,7 +11,7 @@
     "complete": true,
     "options": {
         "dry-run": false,
-        "overwrite-cache": false,
+        "overwrite-records": false,
         "submissions": [
             "course101::hw0::course-student@test.edulinq.org::1697406256",
             "course101::hw0::course-student@test.edulinq.org::1697406265"
@@ -22,6 +22,7 @@
         "complete": true,
         "complete-count": 1,
         "pending-count": 0,
+        "error-count": 0,
         "failure-count": 0,
         "first-timestamp": 1234567890123,
         "last-timestamp": 1234567890123,
@@ -72,5 +73,6 @@
             },
             "total-mean-similarity": 0.13
         }
-    }
+    },
+    "work-errors": {}
 }

--- a/tests/cli/testdata/metadata/metadata_describe_base.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_base.txt
@@ -1097,6 +1097,16 @@
                 }
             ]
         },
+        "metadata/heartbeat": {
+            "description": "Get server heartbeat.",
+            "input": [],
+            "output": [
+                {
+                    "name": "server-version",
+                    "type": "util.Version"
+                }
+            ]
+        },
         "stats/query": {
             "description": "Query stats for the server.",
             "input": [
@@ -1826,6 +1836,24 @@
                 {
                     "name": "to",
                     "type": "[]string"
+                }
+            ]
+        },
+        "jobmanager.JobOptions": {
+            "category": "struct",
+            "description": "The user level options for a job, including an optional context.",
+            "fields": [
+                {
+                    "name": "dry-run",
+                    "type": "bool"
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool"
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool"
                 }
             ]
         },
@@ -2955,6 +2983,23 @@
         "util.FileSpecType": {
             "category": "alias",
             "alias-type": "string"
+        },
+        "util.Version": {
+            "category": "struct",
+            "fields": [
+                {
+                    "name": "base-version",
+                    "type": "string"
+                },
+                {
+                    "name": "git-hash",
+                    "type": "string"
+                },
+                {
+                    "name": "is-dirty",
+                    "type": "bool"
+                }
+            ]
         }
     }
 }

--- a/tests/cli/testdata/metadata/metadata_describe_base.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_base.txt
@@ -145,7 +145,7 @@
                     "type": "bool"
                 },
                 {
-                    "name": "overwrite-cache",
+                    "name": "overwrite-records",
                     "type": "bool"
                 },
                 {
@@ -181,6 +181,10 @@
                 {
                     "name": "summary",
                     "type": "*model.IndividualAnalysisSummary"
+                },
+                {
+                    "name": "work-errors",
+                    "type": "map[string]string"
                 }
             ]
         },
@@ -192,7 +196,7 @@
                     "type": "bool"
                 },
                 {
-                    "name": "overwrite-cache",
+                    "name": "overwrite-records",
                     "type": "bool"
                 },
                 {
@@ -228,6 +232,10 @@
                 {
                     "name": "summary",
                     "type": "*model.PairwiseAnalysisSummary"
+                },
+                {
+                    "name": "work-errors",
+                    "type": "map[string]string"
                 }
             ]
         },
@@ -1383,7 +1391,7 @@
                     "type": "bool"
                 },
                 {
-                    "name": "overwrite-cache",
+                    "name": "overwrite-records",
                     "type": "bool"
                 },
                 {
@@ -1921,6 +1929,10 @@
                     "type": "int"
                 },
                 {
+                    "name": "error-count",
+                    "type": "int"
+                },
+                {
                     "name": "failure-count",
                     "type": "int"
                 },
@@ -2442,6 +2454,10 @@
                     "type": "int"
                 },
                 {
+                    "name": "error-count",
+                    "type": "int"
+                },
+                {
                     "name": "failure-count",
                     "type": "int"
                 },
@@ -2538,6 +2554,10 @@
                 },
                 {
                     "name": "complete-count",
+                    "type": "int"
+                },
+                {
+                    "name": "error-count",
                     "type": "int"
                 },
                 {

--- a/tests/cli/testdata/metadata/metadata_describe_force.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_force.txt
@@ -1099,6 +1099,16 @@
                 }
             ]
         },
+        "metadata/heartbeat": {
+            "description": "Get server heartbeat.",
+            "input": [],
+            "output": [
+                {
+                    "name": "server-version",
+                    "type": "util.Version"
+                }
+            ]
+        },
         "stats/query": {
             "description": "Query stats for the server.",
             "input": [
@@ -2975,6 +2985,23 @@
         "util.FileSpecType": {
             "category": "alias",
             "alias-type": "string"
+        },
+        "util.Version": {
+            "category": "struct",
+            "fields": [
+                {
+                    "name": "base-version",
+                    "type": "string"
+                },
+                {
+                    "name": "git-hash",
+                    "type": "string"
+                },
+                {
+                    "name": "is-dirty",
+                    "type": "bool"
+                }
+            ]
         }
     }
 }

--- a/tests/cli/testdata/metadata/metadata_describe_force.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_force.txt
@@ -147,7 +147,7 @@
                     "type": "bool"
                 },
                 {
-                    "name": "overwrite-cache",
+                    "name": "overwrite-records",
                     "type": "bool"
                 },
                 {
@@ -183,6 +183,10 @@
                 {
                     "name": "summary",
                     "type": "*model.IndividualAnalysisSummary"
+                },
+                {
+                    "name": "work-errors",
+                    "type": "map[string]string"
                 }
             ]
         },
@@ -194,7 +198,7 @@
                     "type": "bool"
                 },
                 {
-                    "name": "overwrite-cache",
+                    "name": "overwrite-records",
                     "type": "bool"
                 },
                 {
@@ -230,6 +234,10 @@
                 {
                     "name": "summary",
                     "type": "*model.PairwiseAnalysisSummary"
+                },
+                {
+                    "name": "work-errors",
+                    "type": "map[string]string"
                 }
             ]
         },
@@ -1385,7 +1393,7 @@
                     "type": "bool"
                 },
                 {
-                    "name": "overwrite-cache",
+                    "name": "overwrite-records",
                     "type": "bool"
                 },
                 {
@@ -1823,6 +1831,24 @@
                 }
             ]
         },
+        "jobmanager.JobOptions": {
+            "category": "struct",
+            "description": "The user level options for a job, including an optional context.",
+            "fields": [
+                {
+                    "name": "dry-run",
+                    "type": "bool"
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool"
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool"
+                }
+            ]
+        },
         "log.LogLevel": {
             "category": "alias",
             "alias-type": "int32"
@@ -1920,6 +1946,10 @@
                 },
                 {
                     "name": "complete-count",
+                    "type": "int"
+                },
+                {
+                    "name": "error-count",
                     "type": "int"
                 },
                 {
@@ -2444,6 +2474,10 @@
                     "type": "int"
                 },
                 {
+                    "name": "error-count",
+                    "type": "int"
+                },
+                {
                     "name": "failure-count",
                     "type": "int"
                 },
@@ -2540,6 +2574,10 @@
                 },
                 {
                     "name": "complete-count",
+                    "type": "int"
+                },
+                {
+                    "name": "error-count",
                     "type": "int"
                 },
                 {


### PR DESCRIPTION
This PR updates the testdata for the updated analysis API endpoint and the new heartbeat API endpoint.

These updates were added to the autograder-server via the following commits, which are present in `autograder-server` version `3.5.1`:

 - https://github.com/edulinq/autograder-server/commit/b370ce694a75894ee34ce6e37a3cff9fdbb05195 updated analysis
 - https://github.com/edulinq/autograder-server/commit/f75d8fe5b0b321ff5746c3951f8fb9b6715e38cc added heartbeat