### PR TITLE
Added support for server user references and updated testdata for new server version.

### DIFF
--- a/.ci/backend.py
+++ b/.ci/backend.py
@@ -17,7 +17,7 @@ import util
 DEFAULT_PORT = 8080
 WEB_URL = 'http://127.0.0.1'
 
-DEFAULT_DOCKER_IMAGE = 'ghcr.io/edulinq/autograder-server:3.5.3-prebuilt'
+DEFAULT_DOCKER_IMAGE = 'ghcr.io/edulinq/autograder-server:3.5.4-prebuilt'
 DOCKER_CONTAINER_NAME = 'autograder-py-verify-test-data'
 DOCKER_START_SLEEP_TIME_SECS = 0.25
 DOCKER_STOP_WAIT_TIME_SECS = 1

--- a/autograder/api/config.py
+++ b/autograder/api/config.py
@@ -383,6 +383,26 @@ PARAM_SEND_EMAILS = APIParam('send-emails',
     'Send any emails.',
     required = True, cli_param = False)
 
+PARAM_SERVER_USER_REFERENCES = APIParam('target-users',
+    ('A list of server user references.'
+    + ' Server user references may be specified in eight ways:'
+    + ' 1) Email address of the requested user,'
+    + ' 2) "*" to request all users in the server,'
+    + ' 3) "<server role>" (e.g., user, creator)'
+    + ' to request all users with that server role,'
+    + ' 4) "<course id>::<course role>" (e.g., course101::student)'
+    + ' to request all users in the target course with that course role,'
+    + ' 5) "*::<course role>" (e.g., *::student)'
+    + ' to request all users with that course role in any course,'
+    + ' 6) "<course id>::*" to request all users in the target course,'
+    + ' 7) "*::*" to request all users enrolled in at least one course,'
+    + ' and 8) any of the previous options preceded by a minus sign'
+    + ' (e.g., "-alice@test.edulinq.org", "-user", "-*::student")'
+    + ' to exclude that user or group from the request.'
+    + ' Default: All users in the server.'),
+    required = False,
+    parser_options = {'action': 'extend', 'type': _csv_to_list})
+
 PARAM_SKIP_BUILD_IMAGES = APIParam('skip-build-images',
     'Skip building assignment Docker images.',
     required = False,

--- a/autograder/api/users/list.py
+++ b/autograder/api/users/list.py
@@ -5,6 +5,8 @@ API_ENDPOINT = 'users/list'
 API_PARAMS = [
     autograder.api.config.PARAM_USER_EMAIL,
     autograder.api.config.PARAM_USER_PASS,
+
+    autograder.api.config.PARAM_SERVER_USER_REFERENCES,
 ]
 
 DESCRIPTION = 'List the users on the server.'

--- a/tests/api/testdata/metadata/metadata_describe_base.json
+++ b/tests/api/testdata/metadata/metadata_describe_base.json
@@ -10,33 +10,29 @@
                 "input": [
                     {
                         "name": "bcc",
-                        "type": "[]model.CourseUserReference",
-                        "required": false
+                        "type": "[]model.CourseUserReference"
                     },
                     {
                         "name": "body",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "cc",
-                        "type": "[]model.CourseUserReference",
-                        "required": false
+                        "type": "[]model.CourseUserReference"
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "dry-run",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "html",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "subject",
@@ -45,17 +41,18 @@
                     },
                     {
                         "name": "to",
-                        "type": "[]model.CourseUserReference",
-                        "required": false
+                        "type": "[]model.CourseUserReference"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -80,16 +77,19 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -106,21 +106,25 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -137,16 +141,19 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -163,32 +170,35 @@
                     {
                         "name": "dry-run",
                         "type": "bool",
-                        "required": false
+                        "description": "Don't save anything."
                     },
                     {
                         "name": "overwrite-records",
                         "type": "bool",
-                        "required": false
+                        "description": "Remove any existing records before running the job."
                     },
                     {
                         "name": "submissions",
                         "type": "[]string",
+                        "description": "The raw submission specifications to analyze.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "wait-for-completion",
                         "type": "bool",
-                        "required": false
+                        "description": "Wait for the entire job to complete and return all results."
                     }
                 ],
                 "output": [
@@ -220,32 +230,35 @@
                     {
                         "name": "dry-run",
                         "type": "bool",
-                        "required": false
+                        "description": "Don't save anything."
                     },
                     {
                         "name": "overwrite-records",
                         "type": "bool",
-                        "required": false
+                        "description": "Remove any existing records before running the job."
                     },
                     {
                         "name": "submissions",
                         "type": "[]string",
+                        "description": "The raw submission specifications to analyze.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "wait-for-completion",
                         "type": "bool",
-                        "required": false
+                        "description": "Wait for the entire job to complete and return all results."
                     }
                 ],
                 "output": [
@@ -277,26 +290,29 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "filter-role",
-                        "type": "int",
-                        "required": false
+                        "type": "int"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -313,26 +329,30 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "filter-role",
                         "type": "int",
-                        "required": false
+                        "description": "Filter results to only users with this role."
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -349,31 +369,33 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "target-submission",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -398,26 +420,29 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -438,26 +463,29 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -478,31 +506,33 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "target-submission",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -527,11 +557,13 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
@@ -541,22 +573,22 @@
                     },
                     {
                         "name": "proxy-time",
-                        "type": "int64",
-                        "required": false
+                        "type": "int64"
                     },
                     {
                         "name": "target-submission",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -593,17 +625,18 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "message",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "proxy-email",
@@ -612,17 +645,18 @@
                     },
                     {
                         "name": "proxy-time",
-                        "type": "int64",
-                        "required": false
+                        "type": "int64"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -655,31 +689,33 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "target-submission",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -699,32 +735,34 @@
                 "input": [
                     {
                         "name": "allow-late",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "message",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -753,21 +791,23 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "dry-run",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -788,47 +828,51 @@
                     {
                         "name": "after",
                         "type": "int64",
-                        "required": false
+                        "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
                     },
                     {
                         "name": "before",
                         "type": "int64",
-                        "required": false
+                        "description": "Only return data from before this time.\nA value of zero is treated as the end of time."
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "limit",
                         "type": "int",
-                        "required": false
+                        "description": "Limit the number of results.\nTake this number of results from the top.\nA non-positive number means no count limit will be applied."
                     },
                     {
                         "name": "sort",
                         "type": "int",
-                        "required": false
+                        "description": "Define how the results should be sorted by time.\n-1 for ascending, 0 for no sorting, 1 for descending."
                     },
                     {
                         "name": "type",
                         "type": "string",
+                        "description": "Only return data of this type.\nThis field is required in the query to specify which kind of metric to return.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "where",
-                        "type": "map[stats.MetricAttribute]interface {}",
-                        "required": false
+                        "type": "map[stats.MetricAttribute]any",
+                        "description": "Filter results to only include metrics that match Metric attribute field values.\nKeys are field names (e.g., \"course\") and values are what to include (e.g., course101).\nThis filter is applied after all other Query conditions are applied."
                     }
                 ],
                 "output": [
@@ -843,8 +887,7 @@
                 "input": [
                     {
                         "name": "dry-run",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "filespec",
@@ -853,37 +896,34 @@
                     },
                     {
                         "name": "skip-build-images",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-emails",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-lms-sync",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-source-sync",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-template-files",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -899,42 +939,38 @@
                 "input": [
                     {
                         "name": "dry-run",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-build-images",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-emails",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-lms-sync",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-source-sync",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-template-files",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -951,6 +987,7 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
@@ -961,11 +998,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -982,12 +1021,13 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "dry-run",
                         "type": "bool",
-                        "required": false
+                        "description": "Do not actually commit any changes or send any emails regardless of |SendEmails|."
                     },
                     {
                         "name": "raw-course-users",
@@ -997,26 +1037,26 @@
                     {
                         "name": "send-emails",
                         "type": "bool",
-                        "required": false
+                        "description": "Send any relevant email (usually about creation or password changing)."
                     },
                     {
                         "name": "skip-inserts",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-updates",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1033,21 +1073,23 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1068,21 +1110,23 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-users",
-                        "type": "[]model.CourseUserReference",
-                        "required": false
+                        "type": "[]model.CourseUserReference"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1104,6 +1148,7 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
@@ -1114,11 +1159,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1147,6 +1194,7 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
@@ -1157,11 +1205,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1185,42 +1235,38 @@
                 "input": [
                     {
                         "name": "after",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "level",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "past",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "target-assignment",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "target-course",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "target-email",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1244,8 +1290,7 @@
                 "input": [
                     {
                         "name": "force-compute",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     }
                 ],
                 "output": [
@@ -1275,42 +1320,45 @@
                     {
                         "name": "after",
                         "type": "int64",
-                        "required": false
+                        "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
                     },
                     {
                         "name": "before",
                         "type": "int64",
-                        "required": false
+                        "description": "Only return data from before this time.\nA value of zero is treated as the end of time."
                     },
                     {
                         "name": "limit",
                         "type": "int",
-                        "required": false
+                        "description": "Limit the number of results.\nTake this number of results from the top.\nA non-positive number means no count limit will be applied."
                     },
                     {
                         "name": "sort",
                         "type": "int",
-                        "required": false
+                        "description": "Define how the results should be sorted by time.\n-1 for ascending, 0 for no sorting, 1 for descending."
                     },
                     {
                         "name": "type",
                         "type": "string",
+                        "description": "Only return data of this type.\nThis field is required in the query to specify which kind of metric to return.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "where",
-                        "type": "map[stats.MetricAttribute]interface {}",
-                        "required": false
+                        "type": "map[stats.MetricAttribute]any",
+                        "description": "Filter results to only include metrics that match Metric attribute field values.\nKeys are field names (e.g., \"course\") and values are what to include (e.g., course101).\nThis filter is applied after all other Query conditions are applied."
                     }
                 ],
                 "output": [
@@ -1326,11 +1374,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1351,11 +1401,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1371,17 +1423,18 @@
                 "input": [
                     {
                         "name": "target-email",
-                        "type": "core.TargetServerUserSelfOrAdmin",
-                        "required": false
+                        "type": "core.TargetServerUserSelfOrAdmin"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1404,13 +1457,19 @@
                 "description": "List the users on the server.",
                 "input": [
                     {
+                        "name": "target-users",
+                        "type": "[]model.ServerUserReference"
+                    },
+                    {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1432,11 +1491,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1473,11 +1534,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1493,17 +1556,18 @@
                 "input": [
                     {
                         "name": "name",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1529,11 +1593,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1550,7 +1616,7 @@
                     {
                         "name": "dry-run",
                         "type": "bool",
-                        "required": false
+                        "description": "Do not actually commit any changes or send any emails regardless of |SendEmails|."
                     },
                     {
                         "name": "raw-users",
@@ -1560,26 +1626,26 @@
                     {
                         "name": "send-emails",
                         "type": "bool",
-                        "required": false
+                        "description": "Send any relevant email (usually about creation or password changing)."
                     },
                     {
                         "name": "skip-inserts",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-updates",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1597,19 +1663,23 @@
                 "fields": [
                     {
                         "name": "dry-run",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "Don't save anything."
                     },
                     {
                         "name": "overwrite-records",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "Remove any existing records before running the job."
                     },
                     {
                         "name": "submissions",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The raw submission specifications to analyze."
                     },
                     {
                         "name": "wait-for-completion",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "Wait for the entire job to complete and return all results."
                     }
                 ]
             },
@@ -1637,6 +1707,10 @@
             "core.BaseFieldDescription": {
                 "category": "struct",
                 "fields": [
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
                     {
                         "name": "name",
                         "type": "string"
@@ -1724,6 +1798,10 @@
             "core.FieldDescription": {
                 "category": "struct",
                 "fields": [
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
                     {
                         "name": "name",
                         "type": "string"
@@ -1875,11 +1953,13 @@
                     },
                     {
                         "name": "attributes",
-                        "type": "map[string]interface {}"
+                        "type": "map[string]any",
+                        "description": "Additional Attributes"
                     },
                     {
                         "name": "course",
-                        "type": "string"
+                        "type": "string",
+                        "description": "Context Attributes"
                     },
                     {
                         "name": "error",
@@ -1887,7 +1967,8 @@
                     },
                     {
                         "name": "level",
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Core Attributes"
                     },
                     {
                         "name": "message",
@@ -2045,51 +2126,63 @@
                 "fields": [
                     {
                         "name": "added",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was added to the server."
                     },
                     {
                         "name": "communication-error",
-                        "type": "*model.ExternalLocatableError"
+                        "type": "*model.ExternalLocatableError",
+                        "description": "A user safe representation of a communication error."
                     },
                     {
                         "name": "dropped",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The user was removed from the following courses (by id)."
                     },
                     {
                         "name": "email",
-                        "type": "string"
+                        "type": "string",
+                        "description": "The email/id of the target user."
                     },
                     {
                         "name": "emailed",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was emailed during the course of this operation.\nThis is more than just GetEmail() was called, an actual email was sent\n(or would have been sent if this operation was during a dry-run)."
                     },
                     {
                         "name": "enrolled",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The user was enrolled in the following courses (by id)."
                     },
                     {
                         "name": "modified",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user existed before this operation and was edited (including enrollment changes)."
                     },
                     {
                         "name": "not-exists",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user did not exist before this operation and does not exist after.\nThis may also be an error depending on the semantics of the operation."
                     },
                     {
                         "name": "removed",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user existed before this operation and was removed."
                     },
                     {
                         "name": "skipped",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was skipped (often because they already exist)."
                     },
                     {
                         "name": "system-error",
-                        "type": "*model.ExternalLocatableError"
+                        "type": "*model.ExternalLocatableError",
+                        "description": "A user safe representation of a system error."
                     },
                     {
                         "name": "validation-error",
-                        "type": "*model.ExternalLocatableError"
+                        "type": "*model.ExternalLocatableError",
+                        "description": "A user safe representation of a validation error, which will not include a locator."
                     }
                 ]
             },
@@ -2102,7 +2195,7 @@
                     },
                     {
                         "name": "options",
-                        "type": "map[string]interface {}"
+                        "type": "map[string]any"
                     },
                     {
                         "name": "original-filename",
@@ -2164,7 +2257,7 @@
                 "fields": [
                     {
                         "name": "additional-info",
-                        "type": "map[string]interface {}"
+                        "type": "map[string]any"
                     },
                     {
                         "name": "assignment-id",
@@ -2570,6 +2663,10 @@
                     }
                 ]
             },
+            "model.ServerUserReference": {
+                "category": "alias",
+                "alias-type": "string"
+            },
             "model.ServerUserRole": {
                 "category": "alias",
                 "alias-type": "int"
@@ -2621,55 +2718,68 @@
                 "fields": [
                     {
                         "name": "added",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was added to the server."
                     },
                     {
                         "name": "cleartext-password",
-                        "type": "string"
+                        "type": "string",
+                        "description": "The following cleartext password was generated during this operation.\nCare should be taken to not expose this field."
                     },
                     {
                         "name": "communication-error",
-                        "type": "*model.LocatableError"
+                        "type": "*model.LocatableError",
+                        "description": "The following error occurred during this operation, but not because of the provided data,\ni.e., the system was unable to communicate the results.\nThese errors are not guaranteed to be safe for users,\nand the calling code should decide how they should be managed."
                     },
                     {
                         "name": "dropped",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The user was removed from the following courses (by id)."
                     },
                     {
                         "name": "email",
-                        "type": "string"
+                        "type": "string",
+                        "description": "The email/id of the target user."
                     },
                     {
                         "name": "emailed",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was emailed during the course of this operation.\nThis is more than just GetEmail() was called, an actual email was sent\n(or would have been sent if this operation was during a dry-run)."
                     },
                     {
                         "name": "enrolled",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The user was enrolled in the following courses (by id)."
                     },
                     {
                         "name": "modified",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user existed before this operation and was edited (including enrollment changes)."
                     },
                     {
                         "name": "not-exists",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user did not exist before this operation and does not exist after.\nThis may also be an error depending on the semantics of the operation."
                     },
                     {
                         "name": "removed",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user existed before this operation and was removed."
                     },
                     {
                         "name": "skipped",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was skipped (often because they already exist)."
                     },
                     {
                         "name": "system-error",
-                        "type": "*model.LocatableError"
+                        "type": "*model.LocatableError",
+                        "description": "The following error occurred during this operation, but not because of the provided data,\ni.e., they are the system's fault.\nThese errors are not guaranteed to be safe for users,\nand the calling code should decide how they should be managed."
                     },
                     {
                         "name": "validation-error",
-                        "type": "*model.LocatableError"
+                        "type": "*model.LocatableError",
+                        "description": "The following error occurred during this operation because of the provided data,\ni.e., they are caused by the calling user.\nAll error messages should be safe for users."
                     }
                 ]
             },
@@ -2678,7 +2788,8 @@
                 "fields": [
                     {
                         "name": "attributes",
-                        "type": "map[stats.MetricAttribute]interface {}"
+                        "type": "map[stats.MetricAttribute]any",
+                        "description": "Additional attributes that are not standard enough to be formalized in fields."
                     },
                     {
                         "name": "timestamp",

--- a/tests/api/testdata/metadata/metadata_describe_force.json
+++ b/tests/api/testdata/metadata/metadata_describe_force.json
@@ -10,33 +10,29 @@
                 "input": [
                     {
                         "name": "bcc",
-                        "type": "[]model.CourseUserReference",
-                        "required": false
+                        "type": "[]model.CourseUserReference"
                     },
                     {
                         "name": "body",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "cc",
-                        "type": "[]model.CourseUserReference",
-                        "required": false
+                        "type": "[]model.CourseUserReference"
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "dry-run",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "html",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "subject",
@@ -45,17 +41,18 @@
                     },
                     {
                         "name": "to",
-                        "type": "[]model.CourseUserReference",
-                        "required": false
+                        "type": "[]model.CourseUserReference"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -80,16 +77,19 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -106,21 +106,25 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -137,16 +141,19 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -163,32 +170,35 @@
                     {
                         "name": "dry-run",
                         "type": "bool",
-                        "required": false
+                        "description": "Don't save anything."
                     },
                     {
                         "name": "overwrite-records",
                         "type": "bool",
-                        "required": false
+                        "description": "Remove any existing records before running the job."
                     },
                     {
                         "name": "submissions",
                         "type": "[]string",
+                        "description": "The raw submission specifications to analyze.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "wait-for-completion",
                         "type": "bool",
-                        "required": false
+                        "description": "Wait for the entire job to complete and return all results."
                     }
                 ],
                 "output": [
@@ -220,32 +230,35 @@
                     {
                         "name": "dry-run",
                         "type": "bool",
-                        "required": false
+                        "description": "Don't save anything."
                     },
                     {
                         "name": "overwrite-records",
                         "type": "bool",
-                        "required": false
+                        "description": "Remove any existing records before running the job."
                     },
                     {
                         "name": "submissions",
                         "type": "[]string",
+                        "description": "The raw submission specifications to analyze.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "wait-for-completion",
                         "type": "bool",
-                        "required": false
+                        "description": "Wait for the entire job to complete and return all results."
                     }
                 ],
                 "output": [
@@ -277,26 +290,29 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "filter-role",
-                        "type": "int",
-                        "required": false
+                        "type": "int"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -313,26 +329,30 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "filter-role",
                         "type": "int",
-                        "required": false
+                        "description": "Filter results to only users with this role."
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -349,31 +369,33 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "target-submission",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -398,26 +420,29 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -438,26 +463,29 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -478,31 +506,33 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "target-submission",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -527,11 +557,13 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
@@ -541,22 +573,22 @@
                     },
                     {
                         "name": "proxy-time",
-                        "type": "int64",
-                        "required": false
+                        "type": "int64"
                     },
                     {
                         "name": "target-submission",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -593,17 +625,18 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "message",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "proxy-email",
@@ -612,17 +645,18 @@
                     },
                     {
                         "name": "proxy-time",
-                        "type": "int64",
-                        "required": false
+                        "type": "int64"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -655,31 +689,33 @@
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "target-submission",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -699,32 +735,34 @@
                 "input": [
                     {
                         "name": "allow-late",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "assignment-id",
                         "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
                         "required": true
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "message",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -753,21 +791,23 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "dry-run",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -788,47 +828,51 @@
                     {
                         "name": "after",
                         "type": "int64",
-                        "required": false
+                        "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
                     },
                     {
                         "name": "before",
                         "type": "int64",
-                        "required": false
+                        "description": "Only return data from before this time.\nA value of zero is treated as the end of time."
                     },
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "limit",
                         "type": "int",
-                        "required": false
+                        "description": "Limit the number of results.\nTake this number of results from the top.\nA non-positive number means no count limit will be applied."
                     },
                     {
                         "name": "sort",
                         "type": "int",
-                        "required": false
+                        "description": "Define how the results should be sorted by time.\n-1 for ascending, 0 for no sorting, 1 for descending."
                     },
                     {
                         "name": "type",
                         "type": "string",
+                        "description": "Only return data of this type.\nThis field is required in the query to specify which kind of metric to return.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "where",
-                        "type": "map[stats.MetricAttribute]interface {}",
-                        "required": false
+                        "type": "map[stats.MetricAttribute]any",
+                        "description": "Filter results to only include metrics that match Metric attribute field values.\nKeys are field names (e.g., \"course\") and values are what to include (e.g., course101).\nThis filter is applied after all other Query conditions are applied."
                     }
                 ],
                 "output": [
@@ -843,8 +887,7 @@
                 "input": [
                     {
                         "name": "dry-run",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "filespec",
@@ -853,37 +896,34 @@
                     },
                     {
                         "name": "skip-build-images",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-emails",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-lms-sync",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-source-sync",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-template-files",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -899,42 +939,38 @@
                 "input": [
                     {
                         "name": "dry-run",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-build-images",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-emails",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-lms-sync",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-source-sync",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-template-files",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -951,6 +987,7 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
@@ -961,11 +998,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -982,12 +1021,13 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "dry-run",
                         "type": "bool",
-                        "required": false
+                        "description": "Do not actually commit any changes or send any emails regardless of |SendEmails|."
                     },
                     {
                         "name": "raw-course-users",
@@ -997,26 +1037,26 @@
                     {
                         "name": "send-emails",
                         "type": "bool",
-                        "required": false
+                        "description": "Send any relevant email (usually about creation or password changing)."
                     },
                     {
                         "name": "skip-inserts",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-updates",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1033,21 +1073,23 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-email",
-                        "type": "core.TargetCourseUserSelfOrGrader",
-                        "required": false
+                        "type": "core.TargetCourseUserSelfOrGrader"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1068,21 +1110,23 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
                         "name": "target-users",
-                        "type": "[]model.CourseUserReference",
-                        "required": false
+                        "type": "[]model.CourseUserReference"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1104,6 +1148,7 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
@@ -1114,11 +1159,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1147,6 +1194,7 @@
                     {
                         "name": "course-id",
                         "type": "string",
+                        "description": "The ID of the course to make this request to.",
                         "required": true
                     },
                     {
@@ -1157,11 +1205,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1185,42 +1235,38 @@
                 "input": [
                     {
                         "name": "after",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "level",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "past",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "target-assignment",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "target-course",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "target-email",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1244,8 +1290,7 @@
                 "input": [
                     {
                         "name": "force-compute",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     }
                 ],
                 "output": [
@@ -1275,42 +1320,45 @@
                     {
                         "name": "after",
                         "type": "int64",
-                        "required": false
+                        "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
                     },
                     {
                         "name": "before",
                         "type": "int64",
-                        "required": false
+                        "description": "Only return data from before this time.\nA value of zero is treated as the end of time."
                     },
                     {
                         "name": "limit",
                         "type": "int",
-                        "required": false
+                        "description": "Limit the number of results.\nTake this number of results from the top.\nA non-positive number means no count limit will be applied."
                     },
                     {
                         "name": "sort",
                         "type": "int",
-                        "required": false
+                        "description": "Define how the results should be sorted by time.\n-1 for ascending, 0 for no sorting, 1 for descending."
                     },
                     {
                         "name": "type",
                         "type": "string",
+                        "description": "Only return data of this type.\nThis field is required in the query to specify which kind of metric to return.",
                         "required": true
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "where",
-                        "type": "map[stats.MetricAttribute]interface {}",
-                        "required": false
+                        "type": "map[stats.MetricAttribute]any",
+                        "description": "Filter results to only include metrics that match Metric attribute field values.\nKeys are field names (e.g., \"course\") and values are what to include (e.g., course101).\nThis filter is applied after all other Query conditions are applied."
                     }
                 ],
                 "output": [
@@ -1326,11 +1374,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1351,11 +1401,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1371,17 +1423,18 @@
                 "input": [
                     {
                         "name": "target-email",
-                        "type": "core.TargetServerUserSelfOrAdmin",
-                        "required": false
+                        "type": "core.TargetServerUserSelfOrAdmin"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1404,13 +1457,19 @@
                 "description": "List the users on the server.",
                 "input": [
                     {
+                        "name": "target-users",
+                        "type": "[]model.ServerUserReference"
+                    },
+                    {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1432,11 +1491,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1473,11 +1534,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1493,17 +1556,18 @@
                 "input": [
                     {
                         "name": "name",
-                        "type": "string",
-                        "required": false
+                        "type": "string"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1529,11 +1593,13 @@
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1550,7 +1616,7 @@
                     {
                         "name": "dry-run",
                         "type": "bool",
-                        "required": false
+                        "description": "Do not actually commit any changes or send any emails regardless of |SendEmails|."
                     },
                     {
                         "name": "raw-users",
@@ -1560,26 +1626,26 @@
                     {
                         "name": "send-emails",
                         "type": "bool",
-                        "required": false
+                        "description": "Send any relevant email (usually about creation or password changing)."
                     },
                     {
                         "name": "skip-inserts",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "skip-updates",
-                        "type": "bool",
-                        "required": false
+                        "type": "bool"
                     },
                     {
                         "name": "user-email",
                         "type": "string",
+                        "description": "The email of the user making this request.",
                         "required": true
                     },
                     {
                         "name": "user-pass",
                         "type": "string",
+                        "description": "The password of the user making this request.",
                         "required": true
                     }
                 ],
@@ -1597,19 +1663,23 @@
                 "fields": [
                     {
                         "name": "dry-run",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "Don't save anything."
                     },
                     {
                         "name": "overwrite-records",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "Remove any existing records before running the job."
                     },
                     {
                         "name": "submissions",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The raw submission specifications to analyze."
                     },
                     {
                         "name": "wait-for-completion",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "Wait for the entire job to complete and return all results."
                     }
                 ]
             },
@@ -1637,6 +1707,10 @@
             "core.BaseFieldDescription": {
                 "category": "struct",
                 "fields": [
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
                     {
                         "name": "name",
                         "type": "string"
@@ -1724,6 +1798,10 @@
             "core.FieldDescription": {
                 "category": "struct",
                 "fields": [
+                    {
+                        "name": "description",
+                        "type": "string"
+                    },
                     {
                         "name": "name",
                         "type": "string"
@@ -1875,11 +1953,13 @@
                     },
                     {
                         "name": "attributes",
-                        "type": "map[string]interface {}"
+                        "type": "map[string]any",
+                        "description": "Additional Attributes"
                     },
                     {
                         "name": "course",
-                        "type": "string"
+                        "type": "string",
+                        "description": "Context Attributes"
                     },
                     {
                         "name": "error",
@@ -1887,7 +1967,8 @@
                     },
                     {
                         "name": "level",
-                        "type": "int32"
+                        "type": "int32",
+                        "description": "Core Attributes"
                     },
                     {
                         "name": "message",
@@ -2045,51 +2126,63 @@
                 "fields": [
                     {
                         "name": "added",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was added to the server."
                     },
                     {
                         "name": "communication-error",
-                        "type": "*model.ExternalLocatableError"
+                        "type": "*model.ExternalLocatableError",
+                        "description": "A user safe representation of a communication error."
                     },
                     {
                         "name": "dropped",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The user was removed from the following courses (by id)."
                     },
                     {
                         "name": "email",
-                        "type": "string"
+                        "type": "string",
+                        "description": "The email/id of the target user."
                     },
                     {
                         "name": "emailed",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was emailed during the course of this operation.\nThis is more than just GetEmail() was called, an actual email was sent\n(or would have been sent if this operation was during a dry-run)."
                     },
                     {
                         "name": "enrolled",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The user was enrolled in the following courses (by id)."
                     },
                     {
                         "name": "modified",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user existed before this operation and was edited (including enrollment changes)."
                     },
                     {
                         "name": "not-exists",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user did not exist before this operation and does not exist after.\nThis may also be an error depending on the semantics of the operation."
                     },
                     {
                         "name": "removed",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user existed before this operation and was removed."
                     },
                     {
                         "name": "skipped",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was skipped (often because they already exist)."
                     },
                     {
                         "name": "system-error",
-                        "type": "*model.ExternalLocatableError"
+                        "type": "*model.ExternalLocatableError",
+                        "description": "A user safe representation of a system error."
                     },
                     {
                         "name": "validation-error",
-                        "type": "*model.ExternalLocatableError"
+                        "type": "*model.ExternalLocatableError",
+                        "description": "A user safe representation of a validation error, which will not include a locator."
                     }
                 ]
             },
@@ -2102,7 +2195,7 @@
                     },
                     {
                         "name": "options",
-                        "type": "map[string]interface {}"
+                        "type": "map[string]any"
                     },
                     {
                         "name": "original-filename",
@@ -2164,7 +2257,7 @@
                 "fields": [
                     {
                         "name": "additional-info",
-                        "type": "map[string]interface {}"
+                        "type": "map[string]any"
                     },
                     {
                         "name": "assignment-id",
@@ -2570,6 +2663,10 @@
                     }
                 ]
             },
+            "model.ServerUserReference": {
+                "category": "alias",
+                "alias-type": "string"
+            },
             "model.ServerUserRole": {
                 "category": "alias",
                 "alias-type": "int"
@@ -2621,55 +2718,68 @@
                 "fields": [
                     {
                         "name": "added",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was added to the server."
                     },
                     {
                         "name": "cleartext-password",
-                        "type": "string"
+                        "type": "string",
+                        "description": "The following cleartext password was generated during this operation.\nCare should be taken to not expose this field."
                     },
                     {
                         "name": "communication-error",
-                        "type": "*model.LocatableError"
+                        "type": "*model.LocatableError",
+                        "description": "The following error occurred during this operation, but not because of the provided data,\ni.e., the system was unable to communicate the results.\nThese errors are not guaranteed to be safe for users,\nand the calling code should decide how they should be managed."
                     },
                     {
                         "name": "dropped",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The user was removed from the following courses (by id)."
                     },
                     {
                         "name": "email",
-                        "type": "string"
+                        "type": "string",
+                        "description": "The email/id of the target user."
                     },
                     {
                         "name": "emailed",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was emailed during the course of this operation.\nThis is more than just GetEmail() was called, an actual email was sent\n(or would have been sent if this operation was during a dry-run)."
                     },
                     {
                         "name": "enrolled",
-                        "type": "[]string"
+                        "type": "[]string",
+                        "description": "The user was enrolled in the following courses (by id)."
                     },
                     {
                         "name": "modified",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user existed before this operation and was edited (including enrollment changes)."
                     },
                     {
                         "name": "not-exists",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user did not exist before this operation and does not exist after.\nThis may also be an error depending on the semantics of the operation."
                     },
                     {
                         "name": "removed",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user existed before this operation and was removed."
                     },
                     {
                         "name": "skipped",
-                        "type": "bool"
+                        "type": "bool",
+                        "description": "The user was skipped (often because they already exist)."
                     },
                     {
                         "name": "system-error",
-                        "type": "*model.LocatableError"
+                        "type": "*model.LocatableError",
+                        "description": "The following error occurred during this operation, but not because of the provided data,\ni.e., they are the system's fault.\nThese errors are not guaranteed to be safe for users,\nand the calling code should decide how they should be managed."
                     },
                     {
                         "name": "validation-error",
-                        "type": "*model.LocatableError"
+                        "type": "*model.LocatableError",
+                        "description": "The following error occurred during this operation because of the provided data,\ni.e., they are caused by the calling user.\nAll error messages should be safe for users."
                     }
                 ]
             },
@@ -2678,7 +2788,8 @@
                 "fields": [
                     {
                         "name": "attributes",
-                        "type": "map[stats.MetricAttribute]interface {}"
+                        "type": "map[stats.MetricAttribute]any",
+                        "description": "Additional attributes that are not standard enough to be formalized in fields."
                     },
                     {
                         "name": "timestamp",

--- a/tests/api/testdata/users/users_list_all.json
+++ b/tests/api/testdata/users/users_list_all.json
@@ -2,7 +2,10 @@
     "module": "autograder.api.users.list",
     "arguments": {
         "user": "server-admin@test.edulinq.org",
-        "pass": "server-admin"
+        "pass": "server-admin",
+        "target-users": [
+            "*"
+        ]
     },
     "output": {
         "users": [

--- a/tests/api/testdata/users/users_list_course.json
+++ b/tests/api/testdata/users/users_list_course.json
@@ -1,0 +1,30 @@
+{
+    "module": "autograder.api.users.list",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-users": [
+            "course101::admin"
+        ]
+    },
+    "output": {
+        "users": [
+            {
+                "type": "server",
+                "email": "course-admin@test.edulinq.org",
+                "name": "course-admin",
+                "role": "user",
+                "courses": {
+                    "course-languages": {
+                        "id": "course-languages",
+                        "role": "admin"
+                    },
+                    "course101": {
+                        "id": "course101",
+                        "role": "admin"
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/tests/api/testdata/users/users_list_email.json
+++ b/tests/api/testdata/users/users_list_email.json
@@ -1,0 +1,38 @@
+{
+    "module": "autograder.api.users.list",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-users": [
+            "course-grader@test.edulinq.org",
+            "server-user@test.edulinq.org"
+        ]
+    },
+    "output": {
+        "users": [
+            {
+                "type": "server",
+                "email": "course-grader@test.edulinq.org",
+                "name": "course-grader",
+                "role": "user",
+                "courses": {
+                    "course-languages": {
+                        "id": "course-languages",
+                        "role": "grader"
+                    },
+                    "course101": {
+                        "id": "course101",
+                        "role": "grader"
+                    }
+                }
+            },
+            {
+                "type": "server",
+                "email": "server-user@test.edulinq.org",
+                "name": "server-user",
+                "role": "user",
+                "courses": {}
+            }
+        ]
+    }
+}

--- a/tests/api/testdata/users/users_list_negative.json
+++ b/tests/api/testdata/users/users_list_negative.json
@@ -1,0 +1,43 @@
+{
+    "module": "autograder.api.users.list",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-users": [
+            "*",
+            "-*::*"
+        ]
+    },
+    "output": {
+        "users": [
+            {
+                "type": "server",
+                "email": "server-admin@test.edulinq.org",
+                "name": "server-admin",
+                "role": "admin",
+                "courses": {}
+            },
+            {
+                "type": "server",
+                "email": "server-creator@test.edulinq.org",
+                "name": "server-creator",
+                "role": "creator",
+                "courses": {}
+            },
+            {
+                "type": "server",
+                "email": "server-owner@test.edulinq.org",
+                "name": "server-owner",
+                "role": "owner",
+                "courses": {}
+            },
+            {
+                "type": "server",
+                "email": "server-user@test.edulinq.org",
+                "name": "server-user",
+                "role": "user",
+                "courses": {}
+            }
+        ]
+    }
+}

--- a/tests/api/testdata/users/users_list_role.json
+++ b/tests/api/testdata/users/users_list_role.json
@@ -1,0 +1,21 @@
+{
+    "module": "autograder.api.users.list",
+    "arguments": {
+        "user": "server-admin@test.edulinq.org",
+        "pass": "server-admin",
+        "target-users": [
+            "creator"
+        ]
+    },
+    "output": {
+        "users": [
+            {
+                "type": "server",
+                "email": "server-creator@test.edulinq.org",
+                "name": "server-creator",
+                "role": "creator",
+                "courses": {}
+            }
+        ]
+    }
+}

--- a/tests/cli/testdata/metadata/metadata_describe_base.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_base.txt
@@ -10,33 +10,29 @@
             "input": [
                 {
                     "name": "bcc",
-                    "type": "[]model.CourseUserReference",
-                    "required": false
+                    "type": "[]model.CourseUserReference"
                 },
                 {
                     "name": "body",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "cc",
-                    "type": "[]model.CourseUserReference",
-                    "required": false
+                    "type": "[]model.CourseUserReference"
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "dry-run",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "html",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "subject",
@@ -45,17 +41,18 @@
                 },
                 {
                     "name": "to",
-                    "type": "[]model.CourseUserReference",
-                    "required": false
+                    "type": "[]model.CourseUserReference"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -80,16 +77,19 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -106,21 +106,25 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -137,16 +141,19 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -163,32 +170,35 @@
                 {
                     "name": "dry-run",
                     "type": "bool",
-                    "required": false
+                    "description": "Don't save anything."
                 },
                 {
                     "name": "overwrite-records",
                     "type": "bool",
-                    "required": false
+                    "description": "Remove any existing records before running the job."
                 },
                 {
                     "name": "submissions",
                     "type": "[]string",
+                    "description": "The raw submission specifications to analyze.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "wait-for-completion",
                     "type": "bool",
-                    "required": false
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ],
             "output": [
@@ -220,32 +230,35 @@
                 {
                     "name": "dry-run",
                     "type": "bool",
-                    "required": false
+                    "description": "Don't save anything."
                 },
                 {
                     "name": "overwrite-records",
                     "type": "bool",
-                    "required": false
+                    "description": "Remove any existing records before running the job."
                 },
                 {
                     "name": "submissions",
                     "type": "[]string",
+                    "description": "The raw submission specifications to analyze.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "wait-for-completion",
                     "type": "bool",
-                    "required": false
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ],
             "output": [
@@ -277,26 +290,29 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "filter-role",
-                    "type": "int",
-                    "required": false
+                    "type": "int"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -313,26 +329,30 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "filter-role",
                     "type": "int",
-                    "required": false
+                    "description": "Filter results to only users with this role."
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -349,31 +369,33 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "target-submission",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -398,26 +420,29 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -438,26 +463,29 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -478,31 +506,33 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "target-submission",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -527,11 +557,13 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
@@ -541,22 +573,22 @@
                 },
                 {
                     "name": "proxy-time",
-                    "type": "int64",
-                    "required": false
+                    "type": "int64"
                 },
                 {
                     "name": "target-submission",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -593,17 +625,18 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "message",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "proxy-email",
@@ -612,17 +645,18 @@
                 },
                 {
                     "name": "proxy-time",
-                    "type": "int64",
-                    "required": false
+                    "type": "int64"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -655,31 +689,33 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "target-submission",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -699,32 +735,34 @@
             "input": [
                 {
                     "name": "allow-late",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "message",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -753,21 +791,23 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "dry-run",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -788,47 +828,51 @@
                 {
                     "name": "after",
                     "type": "int64",
-                    "required": false
+                    "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
                 },
                 {
                     "name": "before",
                     "type": "int64",
-                    "required": false
+                    "description": "Only return data from before this time.\nA value of zero is treated as the end of time."
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
-                    "required": false
+                    "description": "Limit the number of results.\nTake this number of results from the top.\nA non-positive number means no count limit will be applied."
                 },
                 {
                     "name": "sort",
                     "type": "int",
-                    "required": false
+                    "description": "Define how the results should be sorted by time.\n-1 for ascending, 0 for no sorting, 1 for descending."
                 },
                 {
                     "name": "type",
                     "type": "string",
+                    "description": "Only return data of this type.\nThis field is required in the query to specify which kind of metric to return.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "where",
-                    "type": "map[stats.MetricAttribute]interface {}",
-                    "required": false
+                    "type": "map[stats.MetricAttribute]any",
+                    "description": "Filter results to only include metrics that match Metric attribute field values.\nKeys are field names (e.g., \"course\") and values are what to include (e.g., course101).\nThis filter is applied after all other Query conditions are applied."
                 }
             ],
             "output": [
@@ -843,8 +887,7 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "filespec",
@@ -853,37 +896,34 @@
                 },
                 {
                     "name": "skip-build-images",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-emails",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-lms-sync",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-source-sync",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-template-files",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -899,42 +939,38 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-build-images",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-emails",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-lms-sync",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-source-sync",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-template-files",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -951,6 +987,7 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
@@ -961,11 +998,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -982,12 +1021,13 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "dry-run",
                     "type": "bool",
-                    "required": false
+                    "description": "Do not actually commit any changes or send any emails regardless of |SendEmails|."
                 },
                 {
                     "name": "raw-course-users",
@@ -997,26 +1037,26 @@
                 {
                     "name": "send-emails",
                     "type": "bool",
-                    "required": false
+                    "description": "Send any relevant email (usually about creation or password changing)."
                 },
                 {
                     "name": "skip-inserts",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-updates",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1033,21 +1073,23 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1068,21 +1110,23 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-users",
-                    "type": "[]model.CourseUserReference",
-                    "required": false
+                    "type": "[]model.CourseUserReference"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1104,6 +1148,7 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
@@ -1114,11 +1159,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1147,6 +1194,7 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
@@ -1157,11 +1205,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1185,42 +1235,38 @@
             "input": [
                 {
                     "name": "after",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "level",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "past",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "target-assignment",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "target-course",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "target-email",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1244,8 +1290,7 @@
             "input": [
                 {
                     "name": "force-compute",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 }
             ],
             "output": [
@@ -1275,42 +1320,45 @@
                 {
                     "name": "after",
                     "type": "int64",
-                    "required": false
+                    "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
                 },
                 {
                     "name": "before",
                     "type": "int64",
-                    "required": false
+                    "description": "Only return data from before this time.\nA value of zero is treated as the end of time."
                 },
                 {
                     "name": "limit",
                     "type": "int",
-                    "required": false
+                    "description": "Limit the number of results.\nTake this number of results from the top.\nA non-positive number means no count limit will be applied."
                 },
                 {
                     "name": "sort",
                     "type": "int",
-                    "required": false
+                    "description": "Define how the results should be sorted by time.\n-1 for ascending, 0 for no sorting, 1 for descending."
                 },
                 {
                     "name": "type",
                     "type": "string",
+                    "description": "Only return data of this type.\nThis field is required in the query to specify which kind of metric to return.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "where",
-                    "type": "map[stats.MetricAttribute]interface {}",
-                    "required": false
+                    "type": "map[stats.MetricAttribute]any",
+                    "description": "Filter results to only include metrics that match Metric attribute field values.\nKeys are field names (e.g., \"course\") and values are what to include (e.g., course101).\nThis filter is applied after all other Query conditions are applied."
                 }
             ],
             "output": [
@@ -1326,11 +1374,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1351,11 +1401,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1371,17 +1423,18 @@
             "input": [
                 {
                     "name": "target-email",
-                    "type": "core.TargetServerUserSelfOrAdmin",
-                    "required": false
+                    "type": "core.TargetServerUserSelfOrAdmin"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1404,13 +1457,19 @@
             "description": "List the users on the server.",
             "input": [
                 {
+                    "name": "target-users",
+                    "type": "[]model.ServerUserReference"
+                },
+                {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1432,11 +1491,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1473,11 +1534,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1493,17 +1556,18 @@
             "input": [
                 {
                     "name": "name",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1529,11 +1593,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1550,7 +1616,7 @@
                 {
                     "name": "dry-run",
                     "type": "bool",
-                    "required": false
+                    "description": "Do not actually commit any changes or send any emails regardless of |SendEmails|."
                 },
                 {
                     "name": "raw-users",
@@ -1560,26 +1626,26 @@
                 {
                     "name": "send-emails",
                     "type": "bool",
-                    "required": false
+                    "description": "Send any relevant email (usually about creation or password changing)."
                 },
                 {
                     "name": "skip-inserts",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-updates",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1597,19 +1663,23 @@
             "fields": [
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "Don't save anything."
                 },
                 {
                     "name": "overwrite-records",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "Remove any existing records before running the job."
                 },
                 {
                     "name": "submissions",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The raw submission specifications to analyze."
                 },
                 {
                     "name": "wait-for-completion",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ]
         },
@@ -1637,6 +1707,10 @@
         "core.BaseFieldDescription": {
             "category": "struct",
             "fields": [
+                {
+                    "name": "description",
+                    "type": "string"
+                },
                 {
                     "name": "name",
                     "type": "string"
@@ -1724,6 +1798,10 @@
         "core.FieldDescription": {
             "category": "struct",
             "fields": [
+                {
+                    "name": "description",
+                    "type": "string"
+                },
                 {
                     "name": "name",
                     "type": "string"
@@ -1875,11 +1953,13 @@
                 },
                 {
                     "name": "attributes",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]any",
+                    "description": "Additional Attributes"
                 },
                 {
                     "name": "course",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Context Attributes"
                 },
                 {
                     "name": "error",
@@ -1887,7 +1967,8 @@
                 },
                 {
                     "name": "level",
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Core Attributes"
                 },
                 {
                     "name": "message",
@@ -2045,51 +2126,63 @@
             "fields": [
                 {
                     "name": "added",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was added to the server."
                 },
                 {
                     "name": "communication-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "description": "A user safe representation of a communication error."
                 },
                 {
                     "name": "dropped",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The user was removed from the following courses (by id)."
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The email/id of the target user."
                 },
                 {
                     "name": "emailed",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was emailed during the course of this operation.\nThis is more than just GetEmail() was called, an actual email was sent\n(or would have been sent if this operation was during a dry-run)."
                 },
                 {
                     "name": "enrolled",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The user was enrolled in the following courses (by id)."
                 },
                 {
                     "name": "modified",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user existed before this operation and was edited (including enrollment changes)."
                 },
                 {
                     "name": "not-exists",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user did not exist before this operation and does not exist after.\nThis may also be an error depending on the semantics of the operation."
                 },
                 {
                     "name": "removed",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user existed before this operation and was removed."
                 },
                 {
                     "name": "skipped",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was skipped (often because they already exist)."
                 },
                 {
                     "name": "system-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "description": "A user safe representation of a system error."
                 },
                 {
                     "name": "validation-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "description": "A user safe representation of a validation error, which will not include a locator."
                 }
             ]
         },
@@ -2102,7 +2195,7 @@
                 },
                 {
                     "name": "options",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]any"
                 },
                 {
                     "name": "original-filename",
@@ -2164,7 +2257,7 @@
             "fields": [
                 {
                     "name": "additional-info",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]any"
                 },
                 {
                     "name": "assignment-id",
@@ -2570,6 +2663,10 @@
                 }
             ]
         },
+        "model.ServerUserReference": {
+            "category": "alias",
+            "alias-type": "string"
+        },
         "model.ServerUserRole": {
             "category": "alias",
             "alias-type": "int"
@@ -2621,55 +2718,68 @@
             "fields": [
                 {
                     "name": "added",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was added to the server."
                 },
                 {
                     "name": "cleartext-password",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The following cleartext password was generated during this operation.\nCare should be taken to not expose this field."
                 },
                 {
                     "name": "communication-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "description": "The following error occurred during this operation, but not because of the provided data,\ni.e., the system was unable to communicate the results.\nThese errors are not guaranteed to be safe for users,\nand the calling code should decide how they should be managed."
                 },
                 {
                     "name": "dropped",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The user was removed from the following courses (by id)."
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The email/id of the target user."
                 },
                 {
                     "name": "emailed",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was emailed during the course of this operation.\nThis is more than just GetEmail() was called, an actual email was sent\n(or would have been sent if this operation was during a dry-run)."
                 },
                 {
                     "name": "enrolled",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The user was enrolled in the following courses (by id)."
                 },
                 {
                     "name": "modified",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user existed before this operation and was edited (including enrollment changes)."
                 },
                 {
                     "name": "not-exists",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user did not exist before this operation and does not exist after.\nThis may also be an error depending on the semantics of the operation."
                 },
                 {
                     "name": "removed",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user existed before this operation and was removed."
                 },
                 {
                     "name": "skipped",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was skipped (often because they already exist)."
                 },
                 {
                     "name": "system-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "description": "The following error occurred during this operation, but not because of the provided data,\ni.e., they are the system's fault.\nThese errors are not guaranteed to be safe for users,\nand the calling code should decide how they should be managed."
                 },
                 {
                     "name": "validation-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "description": "The following error occurred during this operation because of the provided data,\ni.e., they are caused by the calling user.\nAll error messages should be safe for users."
                 }
             ]
         },
@@ -2678,7 +2788,8 @@
             "fields": [
                 {
                     "name": "attributes",
-                    "type": "map[stats.MetricAttribute]interface {}"
+                    "type": "map[stats.MetricAttribute]any",
+                    "description": "Additional attributes that are not standard enough to be formalized in fields."
                 },
                 {
                     "name": "timestamp",

--- a/tests/cli/testdata/metadata/metadata_describe_force.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_force.txt
@@ -12,33 +12,29 @@
             "input": [
                 {
                     "name": "bcc",
-                    "type": "[]model.CourseUserReference",
-                    "required": false
+                    "type": "[]model.CourseUserReference"
                 },
                 {
                     "name": "body",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "cc",
-                    "type": "[]model.CourseUserReference",
-                    "required": false
+                    "type": "[]model.CourseUserReference"
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "dry-run",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "html",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "subject",
@@ -47,17 +43,18 @@
                 },
                 {
                     "name": "to",
-                    "type": "[]model.CourseUserReference",
-                    "required": false
+                    "type": "[]model.CourseUserReference"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -82,16 +79,19 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -108,21 +108,25 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -139,16 +143,19 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -165,32 +172,35 @@
                 {
                     "name": "dry-run",
                     "type": "bool",
-                    "required": false
+                    "description": "Don't save anything."
                 },
                 {
                     "name": "overwrite-records",
                     "type": "bool",
-                    "required": false
+                    "description": "Remove any existing records before running the job."
                 },
                 {
                     "name": "submissions",
                     "type": "[]string",
+                    "description": "The raw submission specifications to analyze.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "wait-for-completion",
                     "type": "bool",
-                    "required": false
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ],
             "output": [
@@ -222,32 +232,35 @@
                 {
                     "name": "dry-run",
                     "type": "bool",
-                    "required": false
+                    "description": "Don't save anything."
                 },
                 {
                     "name": "overwrite-records",
                     "type": "bool",
-                    "required": false
+                    "description": "Remove any existing records before running the job."
                 },
                 {
                     "name": "submissions",
                     "type": "[]string",
+                    "description": "The raw submission specifications to analyze.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "wait-for-completion",
                     "type": "bool",
-                    "required": false
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ],
             "output": [
@@ -279,26 +292,29 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "filter-role",
-                    "type": "int",
-                    "required": false
+                    "type": "int"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -315,26 +331,30 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "filter-role",
                     "type": "int",
-                    "required": false
+                    "description": "Filter results to only users with this role."
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -351,31 +371,33 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "target-submission",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -400,26 +422,29 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -440,26 +465,29 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -480,31 +508,33 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "target-submission",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -529,11 +559,13 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
@@ -543,22 +575,22 @@
                 },
                 {
                     "name": "proxy-time",
-                    "type": "int64",
-                    "required": false
+                    "type": "int64"
                 },
                 {
                     "name": "target-submission",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -595,17 +627,18 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "message",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "proxy-email",
@@ -614,17 +647,18 @@
                 },
                 {
                     "name": "proxy-time",
-                    "type": "int64",
-                    "required": false
+                    "type": "int64"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -657,31 +691,33 @@
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "target-submission",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -701,32 +737,34 @@
             "input": [
                 {
                     "name": "allow-late",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "assignment-id",
                     "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
                     "required": true
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "message",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -755,21 +793,23 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "dry-run",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -790,47 +830,51 @@
                 {
                     "name": "after",
                     "type": "int64",
-                    "required": false
+                    "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
                 },
                 {
                     "name": "before",
                     "type": "int64",
-                    "required": false
+                    "description": "Only return data from before this time.\nA value of zero is treated as the end of time."
                 },
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "limit",
                     "type": "int",
-                    "required": false
+                    "description": "Limit the number of results.\nTake this number of results from the top.\nA non-positive number means no count limit will be applied."
                 },
                 {
                     "name": "sort",
                     "type": "int",
-                    "required": false
+                    "description": "Define how the results should be sorted by time.\n-1 for ascending, 0 for no sorting, 1 for descending."
                 },
                 {
                     "name": "type",
                     "type": "string",
+                    "description": "Only return data of this type.\nThis field is required in the query to specify which kind of metric to return.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "where",
-                    "type": "map[stats.MetricAttribute]interface {}",
-                    "required": false
+                    "type": "map[stats.MetricAttribute]any",
+                    "description": "Filter results to only include metrics that match Metric attribute field values.\nKeys are field names (e.g., \"course\") and values are what to include (e.g., course101).\nThis filter is applied after all other Query conditions are applied."
                 }
             ],
             "output": [
@@ -845,8 +889,7 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "filespec",
@@ -855,37 +898,34 @@
                 },
                 {
                     "name": "skip-build-images",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-emails",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-lms-sync",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-source-sync",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-template-files",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -901,42 +941,38 @@
             "input": [
                 {
                     "name": "dry-run",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-build-images",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-emails",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-lms-sync",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-source-sync",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-template-files",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -953,6 +989,7 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
@@ -963,11 +1000,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -984,12 +1023,13 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "dry-run",
                     "type": "bool",
-                    "required": false
+                    "description": "Do not actually commit any changes or send any emails regardless of |SendEmails|."
                 },
                 {
                     "name": "raw-course-users",
@@ -999,26 +1039,26 @@
                 {
                     "name": "send-emails",
                     "type": "bool",
-                    "required": false
+                    "description": "Send any relevant email (usually about creation or password changing)."
                 },
                 {
                     "name": "skip-inserts",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-updates",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1035,21 +1075,23 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-email",
-                    "type": "core.TargetCourseUserSelfOrGrader",
-                    "required": false
+                    "type": "core.TargetCourseUserSelfOrGrader"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1070,21 +1112,23 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
                     "name": "target-users",
-                    "type": "[]model.CourseUserReference",
-                    "required": false
+                    "type": "[]model.CourseUserReference"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1106,6 +1150,7 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
@@ -1116,11 +1161,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1149,6 +1196,7 @@
                 {
                     "name": "course-id",
                     "type": "string",
+                    "description": "The ID of the course to make this request to.",
                     "required": true
                 },
                 {
@@ -1159,11 +1207,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1187,42 +1237,38 @@
             "input": [
                 {
                     "name": "after",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "level",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "past",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "target-assignment",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "target-course",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "target-email",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1246,8 +1292,7 @@
             "input": [
                 {
                     "name": "force-compute",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 }
             ],
             "output": [
@@ -1277,42 +1322,45 @@
                 {
                     "name": "after",
                     "type": "int64",
-                    "required": false
+                    "description": "Only return data from after this time.\nA value of zero is treated normally here (as UNIX epoch)."
                 },
                 {
                     "name": "before",
                     "type": "int64",
-                    "required": false
+                    "description": "Only return data from before this time.\nA value of zero is treated as the end of time."
                 },
                 {
                     "name": "limit",
                     "type": "int",
-                    "required": false
+                    "description": "Limit the number of results.\nTake this number of results from the top.\nA non-positive number means no count limit will be applied."
                 },
                 {
                     "name": "sort",
                     "type": "int",
-                    "required": false
+                    "description": "Define how the results should be sorted by time.\n-1 for ascending, 0 for no sorting, 1 for descending."
                 },
                 {
                     "name": "type",
                     "type": "string",
+                    "description": "Only return data of this type.\nThis field is required in the query to specify which kind of metric to return.",
                     "required": true
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "where",
-                    "type": "map[stats.MetricAttribute]interface {}",
-                    "required": false
+                    "type": "map[stats.MetricAttribute]any",
+                    "description": "Filter results to only include metrics that match Metric attribute field values.\nKeys are field names (e.g., \"course\") and values are what to include (e.g., course101).\nThis filter is applied after all other Query conditions are applied."
                 }
             ],
             "output": [
@@ -1328,11 +1376,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1353,11 +1403,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1373,17 +1425,18 @@
             "input": [
                 {
                     "name": "target-email",
-                    "type": "core.TargetServerUserSelfOrAdmin",
-                    "required": false
+                    "type": "core.TargetServerUserSelfOrAdmin"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1406,13 +1459,19 @@
             "description": "List the users on the server.",
             "input": [
                 {
+                    "name": "target-users",
+                    "type": "[]model.ServerUserReference"
+                },
+                {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1434,11 +1493,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1475,11 +1536,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1495,17 +1558,18 @@
             "input": [
                 {
                     "name": "name",
-                    "type": "string",
-                    "required": false
+                    "type": "string"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1531,11 +1595,13 @@
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1552,7 +1618,7 @@
                 {
                     "name": "dry-run",
                     "type": "bool",
-                    "required": false
+                    "description": "Do not actually commit any changes or send any emails regardless of |SendEmails|."
                 },
                 {
                     "name": "raw-users",
@@ -1562,26 +1628,26 @@
                 {
                     "name": "send-emails",
                     "type": "bool",
-                    "required": false
+                    "description": "Send any relevant email (usually about creation or password changing)."
                 },
                 {
                     "name": "skip-inserts",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "skip-updates",
-                    "type": "bool",
-                    "required": false
+                    "type": "bool"
                 },
                 {
                     "name": "user-email",
                     "type": "string",
+                    "description": "The email of the user making this request.",
                     "required": true
                 },
                 {
                     "name": "user-pass",
                     "type": "string",
+                    "description": "The password of the user making this request.",
                     "required": true
                 }
             ],
@@ -1599,19 +1665,23 @@
             "fields": [
                 {
                     "name": "dry-run",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "Don't save anything."
                 },
                 {
                     "name": "overwrite-records",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "Remove any existing records before running the job."
                 },
                 {
                     "name": "submissions",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The raw submission specifications to analyze."
                 },
                 {
                     "name": "wait-for-completion",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ]
         },
@@ -1639,6 +1709,10 @@
         "core.BaseFieldDescription": {
             "category": "struct",
             "fields": [
+                {
+                    "name": "description",
+                    "type": "string"
+                },
                 {
                     "name": "name",
                     "type": "string"
@@ -1726,6 +1800,10 @@
         "core.FieldDescription": {
             "category": "struct",
             "fields": [
+                {
+                    "name": "description",
+                    "type": "string"
+                },
                 {
                     "name": "name",
                     "type": "string"
@@ -1877,11 +1955,13 @@
                 },
                 {
                     "name": "attributes",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]any",
+                    "description": "Additional Attributes"
                 },
                 {
                     "name": "course",
-                    "type": "string"
+                    "type": "string",
+                    "description": "Context Attributes"
                 },
                 {
                     "name": "error",
@@ -1889,7 +1969,8 @@
                 },
                 {
                     "name": "level",
-                    "type": "int32"
+                    "type": "int32",
+                    "description": "Core Attributes"
                 },
                 {
                     "name": "message",
@@ -2047,51 +2128,63 @@
             "fields": [
                 {
                     "name": "added",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was added to the server."
                 },
                 {
                     "name": "communication-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "description": "A user safe representation of a communication error."
                 },
                 {
                     "name": "dropped",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The user was removed from the following courses (by id)."
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The email/id of the target user."
                 },
                 {
                     "name": "emailed",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was emailed during the course of this operation.\nThis is more than just GetEmail() was called, an actual email was sent\n(or would have been sent if this operation was during a dry-run)."
                 },
                 {
                     "name": "enrolled",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The user was enrolled in the following courses (by id)."
                 },
                 {
                     "name": "modified",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user existed before this operation and was edited (including enrollment changes)."
                 },
                 {
                     "name": "not-exists",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user did not exist before this operation and does not exist after.\nThis may also be an error depending on the semantics of the operation."
                 },
                 {
                     "name": "removed",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user existed before this operation and was removed."
                 },
                 {
                     "name": "skipped",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was skipped (often because they already exist)."
                 },
                 {
                     "name": "system-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "description": "A user safe representation of a system error."
                 },
                 {
                     "name": "validation-error",
-                    "type": "*model.ExternalLocatableError"
+                    "type": "*model.ExternalLocatableError",
+                    "description": "A user safe representation of a validation error, which will not include a locator."
                 }
             ]
         },
@@ -2104,7 +2197,7 @@
                 },
                 {
                     "name": "options",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]any"
                 },
                 {
                     "name": "original-filename",
@@ -2166,7 +2259,7 @@
             "fields": [
                 {
                     "name": "additional-info",
-                    "type": "map[string]interface {}"
+                    "type": "map[string]any"
                 },
                 {
                     "name": "assignment-id",
@@ -2572,6 +2665,10 @@
                 }
             ]
         },
+        "model.ServerUserReference": {
+            "category": "alias",
+            "alias-type": "string"
+        },
         "model.ServerUserRole": {
             "category": "alias",
             "alias-type": "int"
@@ -2623,55 +2720,68 @@
             "fields": [
                 {
                     "name": "added",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was added to the server."
                 },
                 {
                     "name": "cleartext-password",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The following cleartext password was generated during this operation.\nCare should be taken to not expose this field."
                 },
                 {
                     "name": "communication-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "description": "The following error occurred during this operation, but not because of the provided data,\ni.e., the system was unable to communicate the results.\nThese errors are not guaranteed to be safe for users,\nand the calling code should decide how they should be managed."
                 },
                 {
                     "name": "dropped",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The user was removed from the following courses (by id)."
                 },
                 {
                     "name": "email",
-                    "type": "string"
+                    "type": "string",
+                    "description": "The email/id of the target user."
                 },
                 {
                     "name": "emailed",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was emailed during the course of this operation.\nThis is more than just GetEmail() was called, an actual email was sent\n(or would have been sent if this operation was during a dry-run)."
                 },
                 {
                     "name": "enrolled",
-                    "type": "[]string"
+                    "type": "[]string",
+                    "description": "The user was enrolled in the following courses (by id)."
                 },
                 {
                     "name": "modified",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user existed before this operation and was edited (including enrollment changes)."
                 },
                 {
                     "name": "not-exists",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user did not exist before this operation and does not exist after.\nThis may also be an error depending on the semantics of the operation."
                 },
                 {
                     "name": "removed",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user existed before this operation and was removed."
                 },
                 {
                     "name": "skipped",
-                    "type": "bool"
+                    "type": "bool",
+                    "description": "The user was skipped (often because they already exist)."
                 },
                 {
                     "name": "system-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "description": "The following error occurred during this operation, but not because of the provided data,\ni.e., they are the system's fault.\nThese errors are not guaranteed to be safe for users,\nand the calling code should decide how they should be managed."
                 },
                 {
                     "name": "validation-error",
-                    "type": "*model.LocatableError"
+                    "type": "*model.LocatableError",
+                    "description": "The following error occurred during this operation because of the provided data,\ni.e., they are caused by the calling user.\nAll error messages should be safe for users."
                 }
             ]
         },
@@ -2680,7 +2790,8 @@
             "fields": [
                 {
                     "name": "attributes",
-                    "type": "map[stats.MetricAttribute]interface {}"
+                    "type": "map[stats.MetricAttribute]any",
+                    "description": "Additional attributes that are not standard enough to be formalized in fields."
                 },
                 {
                     "name": "timestamp",

--- a/tests/cli/testdata/users/users_list_all.txt
+++ b/tests/cli/testdata/users/users_list_all.txt
@@ -2,7 +2,8 @@
     "cli": "autograder.cli.users.list",
     "arguments": [
         "--user", "server-admin@test.edulinq.org",
-        "--pass", "server-admin"
+        "--pass", "server-admin",
+        "--target-users", "*"
     ]
 }
 ---

--- a/tests/cli/testdata/users/users_list_base_normalize.txt
+++ b/tests/cli/testdata/users/users_list_base_normalize.txt
@@ -19,7 +19,6 @@ course-owner@test.edulinq.org	course-owner	user	course-languages	owner
 course-owner@test.edulinq.org	course-owner	user	course101	owner
 course-student@test.edulinq.org	course-student	user	course-languages	student
 course-student@test.edulinq.org	course-student	user	course101	student
-root	root	root		
 server-admin@test.edulinq.org	server-admin	admin		
 server-creator@test.edulinq.org	server-creator	creator		
 server-owner@test.edulinq.org	server-owner	owner		

--- a/tests/cli/testdata/users/users_list_base_table.txt
+++ b/tests/cli/testdata/users/users_list_base_table.txt
@@ -13,7 +13,6 @@ course-grader@test.edulinq.org	course-grader	user	{'course-languages': {'id': 'c
 course-other@test.edulinq.org	course-other	user	{'course-languages': {'id': 'course-languages', 'role': 'other'}, 'course101': {'id': 'course101', 'role': 'other'}}
 course-owner@test.edulinq.org	course-owner	user	{'course-languages': {'id': 'course-languages', 'role': 'owner'}, 'course101': {'id': 'course101', 'role': 'owner'}}
 course-student@test.edulinq.org	course-student	user	{'course-languages': {'id': 'course-languages', 'role': 'student'}, 'course101': {'id': 'course101', 'role': 'student'}}
-root	root	root	{}
 server-admin@test.edulinq.org	server-admin	admin	{}
 server-creator@test.edulinq.org	server-creator	creator	{}
 server-owner@test.edulinq.org	server-owner	owner	{}

--- a/tests/cli/testdata/users/users_list_course.txt
+++ b/tests/cli/testdata/users/users_list_course.txt
@@ -1,0 +1,18 @@
+{
+    "cli": "autograder.cli.users.list",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-users", "course101::admin"
+    ]
+}
+---
+Email: course-admin@test.edulinq.org
+Name: course-admin
+Role: user
+Courses:
+    ID: course-languages
+    Role: admin
+
+    ID: course101
+    Role: admin

--- a/tests/cli/testdata/users/users_list_email_repeated.txt
+++ b/tests/cli/testdata/users/users_list_email_repeated.txt
@@ -1,0 +1,24 @@
+{
+    "cli": "autograder.cli.users.list",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-users", "course-grader@test.edulinq.org",
+        "--target-users", "server-user@test.edulinq.org"
+    ]
+}
+---
+Email: course-grader@test.edulinq.org
+Name: course-grader
+Role: user
+Courses:
+    ID: course-languages
+    Role: grader
+
+    ID: course101
+    Role: grader
+
+Email: server-user@test.edulinq.org
+Name: server-user
+Role: user
+Courses:

--- a/tests/cli/testdata/users/users_list_negative_csv.txt
+++ b/tests/cli/testdata/users/users_list_negative_csv.txt
@@ -1,0 +1,28 @@
+{
+    "cli": "autograder.cli.users.list",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-users", "*,-*::*"
+    ]
+}
+---
+Email: server-admin@test.edulinq.org
+Name: server-admin
+Role: admin
+Courses:
+
+Email: server-creator@test.edulinq.org
+Name: server-creator
+Role: creator
+Courses:
+
+Email: server-owner@test.edulinq.org
+Name: server-owner
+Role: owner
+Courses:
+
+Email: server-user@test.edulinq.org
+Name: server-user
+Role: user
+Courses:

--- a/tests/cli/testdata/users/users_list_role.txt
+++ b/tests/cli/testdata/users/users_list_role.txt
@@ -1,0 +1,13 @@
+{
+    "cli": "autograder.cli.users.list",
+    "arguments": [
+        "--user", "server-admin@test.edulinq.org",
+        "--pass", "server-admin",
+        "--target-users", "creator"
+    ]
+}
+---
+Email: server-creator@test.edulinq.org
+Name: server-creator
+Role: creator
+Courses:


### PR DESCRIPTION
This PR includes updates to the testdata to be compatible with the new server version `3.5.4`.

Additionally, this PR adds support for [server user references](https://github.com/edulinq/autograder-server/blob/f31ccf9ad09679949937944d5155e18aa1f57aa7/internal/model/server_user_reference.go#L12-L21) for the `users/list` API endpoint.