### PR TITLE
Added support for the proxy/regrade API endpoint.

### DIFF
--- a/.ci/backend.py
+++ b/.ci/backend.py
@@ -17,7 +17,7 @@ import util
 DEFAULT_PORT = 8080
 WEB_URL = 'http://127.0.0.1'
 
-DEFAULT_DOCKER_IMAGE = 'ghcr.io/edulinq/autograder-server:3.5.5-prebuilt'
+DEFAULT_DOCKER_IMAGE = 'ghcr.io/edulinq/autograder-server:3.5.6-prebuilt'
 DOCKER_CONTAINER_NAME = 'autograder-py-verify-test-data'
 DOCKER_START_SLEEP_TIME_SECS = 0.25
 DOCKER_STOP_WAIT_TIME_SECS = 1

--- a/autograder/api/config.py
+++ b/autograder/api/config.py
@@ -379,6 +379,15 @@ PARAM_QUERY_WHERE = APIParam('where',
         'nargs': '+',
     })
 
+PARAM_REGRADE_AFTER = APIParam('regrade-after',
+    ('The timestamp that will be applied to the request.'
+    + ' Every target user will have a new submission after this time.'
+    + ' By default, the current time will be used.'
+    + ' Use this option to manually set the regrade time.'
+    + ' Timestamps are milliseconds from the UNIX epoch'
+    + ' (https://en.wikipedia.org/wiki/Unix_time).'),
+    required = False, parser_options = {'action': 'store', 'type': int})
+
 PARAM_SEND_EMAILS = APIParam('send-emails',
     'Send any emails.',
     required = True, cli_param = False)

--- a/autograder/api/config.py
+++ b/autograder/api/config.py
@@ -379,12 +379,10 @@ PARAM_QUERY_WHERE = APIParam('where',
         'nargs': '+',
     })
 
-PARAM_REGRADE_AFTER = APIParam('regrade-after',
-    ('The timestamp that will be applied to the request.'
-    + ' Every target user will have a new submission after this time.'
+PARAM_REGRADE_CUTOFF = APIParam('regrade-cutoff',
+    ('All submissions occuring before the cutoff time will be regraded.'
     + ' By default, the current time will be used.'
-    + ' Use this option to manually set the regrade time.'
-    + ' Timestamps are milliseconds from the UNIX epoch'
+    + ' Time is milliseconds from the UNIX epoch'
     + ' (https://en.wikipedia.org/wiki/Unix_time).'),
     required = False, parser_options = {'action': 'store', 'type': int})
 

--- a/autograder/api/courses/assignments/submissions/proxy/regrade.py
+++ b/autograder/api/courses/assignments/submissions/proxy/regrade.py
@@ -1,0 +1,29 @@
+import autograder.api.common
+import autograder.api.config
+
+API_ENDPOINT = 'courses/assignments/submissions/proxy/regrade'
+API_PARAMS = [
+    autograder.api.config.PARAM_COURSE_ID,
+    autograder.api.config.PARAM_USER_EMAIL,
+    autograder.api.config.PARAM_USER_PASS,
+    autograder.api.config.PARAM_ASSIGNMENT_ID,
+
+    autograder.api.config.PARAM_COURSE_USER_REFERENCES,
+    autograder.api.config.PARAM_REGRADE_AFTER,
+
+    autograder.api.config.PARAM_DRY_RUN,
+    autograder.api.config.PARAM_OVERWRITE_RECORDS,
+    autograder.api.config.PARAM_WAIT_FOR_COMPLETION,
+]
+
+DESCRIPTION = 'Proxy regrade an assignment for all target users using their most recent submission.'
+
+def send(arguments, **kwargs):
+    return autograder.api.common.handle_api_request(arguments, API_PARAMS, API_ENDPOINT, **kwargs)
+
+def _get_parser():
+    parser = autograder.api.config.get_argument_parser(
+        description = DESCRIPTION,
+        params = API_PARAMS)
+
+    return parser

--- a/autograder/api/courses/assignments/submissions/proxy/regrade.py
+++ b/autograder/api/courses/assignments/submissions/proxy/regrade.py
@@ -9,7 +9,7 @@ API_PARAMS = [
     autograder.api.config.PARAM_ASSIGNMENT_ID,
 
     autograder.api.config.PARAM_COURSE_USER_REFERENCES,
-    autograder.api.config.PARAM_REGRADE_AFTER,
+    autograder.api.config.PARAM_REGRADE_CUTOFF,
 
     autograder.api.config.PARAM_DRY_RUN,
     autograder.api.config.PARAM_OVERWRITE_RECORDS,

--- a/autograder/cli/courses/assignments/submissions/proxy/regrade.py
+++ b/autograder/cli/courses/assignments/submissions/proxy/regrade.py
@@ -1,0 +1,23 @@
+import json
+import sys
+
+import autograder.api.courses.assignments.submissions.proxy.regrade
+import autograder.cli.common
+import autograder.cli.config
+
+def run(arguments):
+    result = autograder.api.courses.assignments.submissions.proxy.regrade.send(
+            arguments, exit_on_error = True)
+
+    print(json.dumps(result, indent = 4))
+    return 0
+
+def main():
+    return run(_get_parser().parse_args())
+
+def _get_parser():
+    parser = autograder.api.courses.assignments.submissions.proxy.regrade._get_parser()
+    return parser
+
+if (__name__ == '__main__'):
+    sys.exit(main())

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_base.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_base.json
@@ -1,0 +1,32 @@
+{
+    "module": "autograder.api.courses.assignments.submissions.proxy.regrade",
+    "read-write": true,
+    "arguments": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "wait-for-completion": false
+    },
+    "output-modifier": "clean_output_timestamps_and_submission_ids",
+    "output": {
+		"options": {
+			"dry-run": false,
+			"overwrite-records": false,
+			"wait-for-completion": false,
+			"target-users": [
+				"*"
+			],
+			"regrade-after": 1234567890123
+		},
+		"regrade-after": 1234567890123,
+		"results": {},
+		"work-errors": {},
+		"complete": false,
+		"resolved-users": [
+			"course-admin@test.edulinq.org",
+			"course-grader@test.edulinq.org",
+			"course-other@test.edulinq.org",
+			"course-owner@test.edulinq.org",
+			"course-student@test.edulinq.org"
+		]
+    }
+}

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_base.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_base.json
@@ -15,9 +15,8 @@
 			"target-users": [
 				"*"
 			],
-			"regrade-after": 1234567890123
+			"regrade-cutoff": 1234567890123
 		},
-		"regrade-after": 1234567890123,
 		"results": {},
 		"work-errors": {},
 		"complete": false,

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_dryrun.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_dryrun.json
@@ -1,0 +1,32 @@
+{
+    "module": "autograder.api.courses.assignments.submissions.proxy.regrade",
+    "read-write": true,
+    "arguments": {
+        "dry-run": true,
+        "overwrite-records": false,
+        "wait-for-completion": false
+    },
+    "output-modifier": "clean_output_timestamps_and_submission_ids",
+    "output": {
+		"options": {
+			"dry-run": true,
+			"overwrite-records": false,
+			"wait-for-completion": false,
+			"target-users": [
+				"*"
+			],
+			"regrade-after": 1234567890123
+		},
+		"regrade-after": 1234567890123,
+		"results": {},
+		"work-errors": {},
+		"complete": false,
+		"resolved-users": [
+			"course-admin@test.edulinq.org",
+			"course-grader@test.edulinq.org",
+			"course-other@test.edulinq.org",
+			"course-owner@test.edulinq.org",
+			"course-student@test.edulinq.org"
+		]
+    }
+}

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_dryrun.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_dryrun.json
@@ -15,9 +15,8 @@
 			"target-users": [
 				"*"
 			],
-			"regrade-after": 1234567890123
+			"regrade-cutoff": 1234567890123
 		},
-		"regrade-after": 1234567890123,
 		"results": {},
 		"work-errors": {},
 		"complete": false,

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_negative.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_negative.json
@@ -1,0 +1,36 @@
+{
+    "module": "autograder.api.courses.assignments.submissions.proxy.regrade",
+    "read-write": true,
+    "arguments": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "target-users": [
+            "*",
+            "-course-admin@test.edulinq.org"
+        ],
+        "wait-for-completion": false
+    },
+    "output-modifier": "clean_output_timestamps_and_submission_ids",
+    "output": {
+		"options": {
+			"dry-run": false,
+			"overwrite-records": false,
+			"wait-for-completion": false,
+			"target-users": [
+				"*",
+                "-course-admin@test.edulinq.org"
+			],
+			"regrade-after": 1234567890123
+		},
+		"regrade-after": 1234567890123,
+		"results": {},
+		"work-errors": {},
+		"complete": false,
+		"resolved-users": [
+			"course-grader@test.edulinq.org",
+			"course-other@test.edulinq.org",
+			"course-owner@test.edulinq.org",
+			"course-student@test.edulinq.org"
+		]
+    }
+}

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_negative.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_negative.json
@@ -20,9 +20,8 @@
 				"*",
                 "-course-admin@test.edulinq.org"
 			],
-			"regrade-after": 1234567890123
+			"regrade-cutoff": 1234567890123
 		},
-		"regrade-after": 1234567890123,
 		"results": {},
 		"work-errors": {},
 		"complete": false,

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_overwriterecords.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_overwriterecords.json
@@ -1,0 +1,32 @@
+{
+    "module": "autograder.api.courses.assignments.submissions.proxy.regrade",
+    "read-write": true,
+    "arguments": {
+        "dry-run": false,
+        "overwrite-records": true,
+        "wait-for-completion": false
+    },
+    "output-modifier": "clean_output_timestamps_and_submission_ids",
+    "output": {
+		"options": {
+			"dry-run": false,
+			"overwrite-records": true,
+			"wait-for-completion": false,
+			"target-users": [
+				"*"
+			],
+			"regrade-after": 1234567890123
+		},
+		"regrade-after": 1234567890123,
+		"results": {},
+		"work-errors": {},
+		"complete": false,
+		"resolved-users": [
+			"course-admin@test.edulinq.org",
+			"course-grader@test.edulinq.org",
+			"course-other@test.edulinq.org",
+			"course-owner@test.edulinq.org",
+			"course-student@test.edulinq.org"
+		]
+    }
+}

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_overwriterecords.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_overwriterecords.json
@@ -15,9 +15,8 @@
 			"target-users": [
 				"*"
 			],
-			"regrade-after": 1234567890123
+			"regrade-cutoff": 1234567890123
 		},
-		"regrade-after": 1234567890123,
 		"results": {},
 		"work-errors": {},
 		"complete": false,

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_role.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_role.json
@@ -1,0 +1,31 @@
+{
+    "module": "autograder.api.courses.assignments.submissions.proxy.regrade",
+    "read-write": true,
+    "arguments": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "target-users": [
+            "student"
+        ],
+        "wait-for-completion": false
+    },
+    "output-modifier": "clean_output_timestamps_and_submission_ids",
+    "output": {
+		"options": {
+			"dry-run": false,
+			"overwrite-records": false,
+			"wait-for-completion": false,
+			"target-users": [
+				"student"
+			],
+			"regrade-after": 1234567890123
+		},
+		"regrade-after": 1234567890123,
+		"results": {},
+		"work-errors": {},
+		"complete": false,
+		"resolved-users": [
+			"course-student@test.edulinq.org"
+		]
+    }
+}

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_role.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_role.json
@@ -18,9 +18,8 @@
 			"target-users": [
 				"student"
 			],
-			"regrade-after": 1234567890123
+			"regrade-cutoff": 1234567890123
 		},
-		"regrade-after": 1234567890123,
 		"results": {},
 		"work-errors": {},
 		"complete": false,

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_time.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_time.json
@@ -4,7 +4,7 @@
     "arguments": {
         "dry-run": false,
         "overwrite-records": false,
-        "regrade-after": 0,
+        "regrade-cutoff": 0,
         "wait-for-completion": false
     },
     "output-modifier": "clean_output_timestamps_and_submission_ids",
@@ -16,9 +16,8 @@
 			"target-users": [
 				"*"
 			],
-			"regrade-after": 0
+			"regrade-cutoff": 0
 		},
-		"regrade-after": 0,
 		"results": {
 			"course-student@test.edulinq.org": {
 				"id": "course101::hw0::course-student@test.edulinq.org::1234567890",

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_time.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_time.json
@@ -1,0 +1,45 @@
+{
+    "module": "autograder.api.courses.assignments.submissions.proxy.regrade",
+    "read-write": true,
+    "arguments": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "regrade-after": 0,
+        "wait-for-completion": false
+    },
+    "output-modifier": "clean_output_timestamps_and_submission_ids",
+    "output": {
+		"options": {
+			"dry-run": false,
+			"overwrite-records": false,
+			"wait-for-completion": false,
+			"target-users": [
+				"*"
+			],
+			"regrade-after": 0
+		},
+		"regrade-after": 0,
+		"results": {
+			"course-student@test.edulinq.org": {
+				"id": "course101::hw0::course-student@test.edulinq.org::1234567890",
+				"short-id": "1234567890",
+				"course-id": "course101",
+				"assignment-id": "hw0",
+				"user": "course-student@test.edulinq.org",
+				"message": "",
+				"max_points": 2,
+				"score": 2,
+				"grading_start_time": 1234567890123
+			}
+        },
+		"work-errors": {},
+		"complete": false,
+		"resolved-users": [
+			"course-admin@test.edulinq.org",
+			"course-grader@test.edulinq.org",
+			"course-other@test.edulinq.org",
+			"course-owner@test.edulinq.org",
+			"course-student@test.edulinq.org"
+		]
+    }
+}

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_wait.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_wait.json
@@ -15,9 +15,8 @@
 			"target-users": [
 				"*"
 			],
-			"regrade-after": 1234567890123
+			"regrade-cutoff": 1234567890123
 		},
-		"regrade-after": 1234567890123,
 		"results": {
 			"course-admin@test.edulinq.org": null,
 			"course-grader@test.edulinq.org": null,

--- a/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_wait.json
+++ b/tests/api/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_wait.json
@@ -1,0 +1,48 @@
+{
+    "module": "autograder.api.courses.assignments.submissions.proxy.regrade",
+    "read-write": true,
+    "arguments": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "wait-for-completion": true
+    },
+    "output-modifier": "clean_output_timestamps_and_submission_ids",
+    "output": {
+		"options": {
+			"dry-run": false,
+			"overwrite-records": false,
+			"wait-for-completion": true,
+			"target-users": [
+				"*"
+			],
+			"regrade-after": 1234567890123
+		},
+		"regrade-after": 1234567890123,
+		"results": {
+			"course-admin@test.edulinq.org": null,
+			"course-grader@test.edulinq.org": null,
+			"course-other@test.edulinq.org": null,
+			"course-owner@test.edulinq.org": null,
+			"course-student@test.edulinq.org": {
+				"id": "course101::hw0::course-student@test.edulinq.org::1234567890",
+				"short-id": "1234567890",
+				"course-id": "course101",
+				"assignment-id": "hw0",
+				"user": "course-student@test.edulinq.org",
+				"message": "",
+				"max_points": 2,
+				"score": 2,
+				"grading_start_time": 1234567890123
+			}
+        },
+		"work-errors": {},
+		"complete": true,
+		"resolved-users": [
+			"course-admin@test.edulinq.org",
+			"course-grader@test.edulinq.org",
+			"course-other@test.edulinq.org",
+			"course-owner@test.edulinq.org",
+			"course-student@test.edulinq.org"
+		]
+    }
+}

--- a/tests/api/testdata/metadata/metadata_describe_base.json
+++ b/tests/api/testdata/metadata/metadata_describe_base.json
@@ -552,6 +552,87 @@
                     }
                 ]
             },
+            "courses/assignments/submissions/proxy/regrade": {
+                "description": "Proxy regrade an assignment for all target users using their most recent submission.",
+                "input": [
+                    {
+                        "name": "assignment-id",
+                        "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
+                        "required": true
+                    },
+                    {
+                        "name": "course-id",
+                        "type": "string",
+                        "description": "The ID of the course to make this request to.",
+                        "required": true
+                    },
+                    {
+                        "name": "dry-run",
+                        "type": "bool",
+                        "description": "Don't save anything."
+                    },
+                    {
+                        "name": "overwrite-records",
+                        "type": "bool",
+                        "description": "Remove any existing records before running the job."
+                    },
+                    {
+                        "name": "regrade-after",
+                        "type": "int64",
+                        "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                    },
+                    {
+                        "name": "target-users",
+                        "type": "[]model.CourseUserReference",
+                        "description": "The raw course user references to regrade.",
+                        "required": true
+                    },
+                    {
+                        "name": "user-email",
+                        "type": "string",
+                        "description": "The email of the user making this request.",
+                        "required": true
+                    },
+                    {
+                        "name": "user-pass",
+                        "type": "string",
+                        "description": "The password of the user making this request.",
+                        "required": true
+                    },
+                    {
+                        "name": "wait-for-completion",
+                        "type": "bool",
+                        "description": "Wait for the entire job to complete and return all results."
+                    }
+                ],
+                "output": [
+                    {
+                        "name": "complete",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "options",
+                        "type": "grader.RegradeOptions"
+                    },
+                    {
+                        "name": "regrade-after",
+                        "type": "int64"
+                    },
+                    {
+                        "name": "resolved-users",
+                        "type": "[]string"
+                    },
+                    {
+                        "name": "results",
+                        "type": "map[string]*model.SubmissionHistoryItem"
+                    },
+                    {
+                        "name": "work-errors",
+                        "type": "map[string]string"
+                    }
+                ]
+            },
             "courses/assignments/submissions/proxy/resubmit": {
                 "description": "Proxy resubmit an assignment submission to the autograder.",
                 "input": [
@@ -1939,6 +2020,36 @@
                     {
                         "name": "updated",
                         "type": "bool"
+                    }
+                ]
+            },
+            "grader.RegradeOptions": {
+                "category": "struct",
+                "fields": [
+                    {
+                        "name": "dry-run",
+                        "type": "bool",
+                        "description": "Don't save anything."
+                    },
+                    {
+                        "name": "overwrite-records",
+                        "type": "bool",
+                        "description": "Remove any existing records before running the job."
+                    },
+                    {
+                        "name": "regrade-after",
+                        "type": "int64",
+                        "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                    },
+                    {
+                        "name": "target-users",
+                        "type": "[]model.CourseUserReference",
+                        "description": "The raw course user references to regrade."
+                    },
+                    {
+                        "name": "wait-for-completion",
+                        "type": "bool",
+                        "description": "Wait for the entire job to complete and return all results."
                     }
                 ]
             },

--- a/tests/api/testdata/metadata/metadata_describe_base.json
+++ b/tests/api/testdata/metadata/metadata_describe_base.json
@@ -578,7 +578,7 @@
                         "description": "Remove any existing records before running the job."
                     },
                     {
-                        "name": "regrade-after",
+                        "name": "regrade-cutoff",
                         "type": "int64",
                         "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                     },
@@ -614,10 +614,6 @@
                     {
                         "name": "options",
                         "type": "grader.RegradeOptions"
-                    },
-                    {
-                        "name": "regrade-after",
-                        "type": "int64"
                     },
                     {
                         "name": "resolved-users",
@@ -2037,7 +2033,7 @@
                         "description": "Remove any existing records before running the job."
                     },
                     {
-                        "name": "regrade-after",
+                        "name": "regrade-cutoff",
                         "type": "int64",
                         "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                     },

--- a/tests/api/testdata/metadata/metadata_describe_force.json
+++ b/tests/api/testdata/metadata/metadata_describe_force.json
@@ -552,6 +552,87 @@
                     }
                 ]
             },
+            "courses/assignments/submissions/proxy/regrade": {
+                "description": "Proxy regrade an assignment for all target users using their most recent submission.",
+                "input": [
+                    {
+                        "name": "assignment-id",
+                        "type": "string",
+                        "description": "The ID of the assignment to make this request to.",
+                        "required": true
+                    },
+                    {
+                        "name": "course-id",
+                        "type": "string",
+                        "description": "The ID of the course to make this request to.",
+                        "required": true
+                    },
+                    {
+                        "name": "dry-run",
+                        "type": "bool",
+                        "description": "Don't save anything."
+                    },
+                    {
+                        "name": "overwrite-records",
+                        "type": "bool",
+                        "description": "Remove any existing records before running the job."
+                    },
+                    {
+                        "name": "regrade-after",
+                        "type": "int64",
+                        "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                    },
+                    {
+                        "name": "target-users",
+                        "type": "[]model.CourseUserReference",
+                        "description": "The raw course user references to regrade.",
+                        "required": true
+                    },
+                    {
+                        "name": "user-email",
+                        "type": "string",
+                        "description": "The email of the user making this request.",
+                        "required": true
+                    },
+                    {
+                        "name": "user-pass",
+                        "type": "string",
+                        "description": "The password of the user making this request.",
+                        "required": true
+                    },
+                    {
+                        "name": "wait-for-completion",
+                        "type": "bool",
+                        "description": "Wait for the entire job to complete and return all results."
+                    }
+                ],
+                "output": [
+                    {
+                        "name": "complete",
+                        "type": "bool"
+                    },
+                    {
+                        "name": "options",
+                        "type": "grader.RegradeOptions"
+                    },
+                    {
+                        "name": "regrade-after",
+                        "type": "int64"
+                    },
+                    {
+                        "name": "resolved-users",
+                        "type": "[]string"
+                    },
+                    {
+                        "name": "results",
+                        "type": "map[string]*model.SubmissionHistoryItem"
+                    },
+                    {
+                        "name": "work-errors",
+                        "type": "map[string]string"
+                    }
+                ]
+            },
             "courses/assignments/submissions/proxy/resubmit": {
                 "description": "Proxy resubmit an assignment submission to the autograder.",
                 "input": [
@@ -1939,6 +2020,36 @@
                     {
                         "name": "updated",
                         "type": "bool"
+                    }
+                ]
+            },
+            "grader.RegradeOptions": {
+                "category": "struct",
+                "fields": [
+                    {
+                        "name": "dry-run",
+                        "type": "bool",
+                        "description": "Don't save anything."
+                    },
+                    {
+                        "name": "overwrite-records",
+                        "type": "bool",
+                        "description": "Remove any existing records before running the job."
+                    },
+                    {
+                        "name": "regrade-after",
+                        "type": "int64",
+                        "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                    },
+                    {
+                        "name": "target-users",
+                        "type": "[]model.CourseUserReference",
+                        "description": "The raw course user references to regrade."
+                    },
+                    {
+                        "name": "wait-for-completion",
+                        "type": "bool",
+                        "description": "Wait for the entire job to complete and return all results."
                     }
                 ]
             },

--- a/tests/api/testdata/metadata/metadata_describe_force.json
+++ b/tests/api/testdata/metadata/metadata_describe_force.json
@@ -578,7 +578,7 @@
                         "description": "Remove any existing records before running the job."
                     },
                     {
-                        "name": "regrade-after",
+                        "name": "regrade-cutoff",
                         "type": "int64",
                         "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                     },
@@ -614,10 +614,6 @@
                     {
                         "name": "options",
                         "type": "grader.RegradeOptions"
-                    },
-                    {
-                        "name": "regrade-after",
-                        "type": "int64"
                     },
                     {
                         "name": "resolved-users",
@@ -2037,7 +2033,7 @@
                         "description": "Remove any existing records before running the job."
                     },
                     {
-                        "name": "regrade-after",
+                        "name": "regrade-cutoff",
                         "type": "int64",
                         "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                     },

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_base.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_base.txt
@@ -12,9 +12,8 @@
         "target-users": [
             "*"
         ],
-        "regrade-after": 1234567890123
+        "regrade-cutoff": 1234567890123
     },
-    "regrade-after": 1234567890123,
     "results": {},
     "work-errors": {},
     "complete": false,

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_base.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_base.txt
@@ -1,0 +1,28 @@
+{
+    "cli": "autograder.cli.courses.assignments.submissions.proxy.regrade",
+    "output-check": "content_equals_ignore_time",
+    "arguments": []
+}
+---
+{
+    "options": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "wait-for-completion": false,
+        "target-users": [
+            "*"
+        ],
+        "regrade-after": 1234567890123
+    },
+    "regrade-after": 1234567890123,
+    "results": {},
+    "work-errors": {},
+    "complete": false,
+    "resolved-users": [
+        "course-admin@test.edulinq.org",
+        "course-grader@test.edulinq.org",
+        "course-other@test.edulinq.org",
+        "course-owner@test.edulinq.org",
+        "course-student@test.edulinq.org"
+    ]
+}

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_dryrun.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_dryrun.txt
@@ -14,9 +14,8 @@
         "target-users": [
             "*"
         ],
-        "regrade-after": 1234567890123
+        "regrade-cutoff": 1234567890123
     },
-    "regrade-after": 1234567890123,
     "results": {},
     "work-errors": {},
     "complete": false,

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_dryrun.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_dryrun.txt
@@ -1,0 +1,30 @@
+{
+    "cli": "autograder.cli.courses.assignments.submissions.proxy.regrade",
+    "output-check": "content_equals_ignore_time",
+    "arguments": [
+        "--dry-run"
+    ]
+}
+---
+{
+    "options": {
+        "dry-run": true,
+        "overwrite-records": false,
+        "wait-for-completion": false,
+        "target-users": [
+            "*"
+        ],
+        "regrade-after": 1234567890123
+    },
+    "regrade-after": 1234567890123,
+    "results": {},
+    "work-errors": {},
+    "complete": false,
+    "resolved-users": [
+        "course-admin@test.edulinq.org",
+        "course-grader@test.edulinq.org",
+        "course-other@test.edulinq.org",
+        "course-owner@test.edulinq.org",
+        "course-student@test.edulinq.org"
+    ]
+}

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_negative.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_negative.txt
@@ -15,9 +15,8 @@
             "*",
             "-course-admin@test.edulinq.org"
         ],
-        "regrade-after": 1234567890123
+        "regrade-cutoff": 1234567890123
     },
-    "regrade-after": 1234567890123,
     "results": {},
     "work-errors": {},
     "complete": false,

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_negative.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_negative.txt
@@ -1,0 +1,30 @@
+{
+    "cli": "autograder.cli.courses.assignments.submissions.proxy.regrade",
+    "output-check": "content_equals_ignore_time",
+    "arguments": [
+        "--target-users", "*,-course-admin@test.edulinq.org"
+    ]
+}
+---
+{
+    "options": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "wait-for-completion": false,
+        "target-users": [
+            "*",
+            "-course-admin@test.edulinq.org"
+        ],
+        "regrade-after": 1234567890123
+    },
+    "regrade-after": 1234567890123,
+    "results": {},
+    "work-errors": {},
+    "complete": false,
+    "resolved-users": [
+        "course-grader@test.edulinq.org",
+        "course-other@test.edulinq.org",
+        "course-owner@test.edulinq.org",
+        "course-student@test.edulinq.org"
+    ]
+}

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_overwriterecords.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_overwriterecords.txt
@@ -14,9 +14,8 @@
         "target-users": [
             "*"
         ],
-        "regrade-after": 1234567890123
+        "regrade-cutoff": 1234567890123
     },
-    "regrade-after": 1234567890123,
     "results": {},
     "work-errors": {},
     "complete": false,

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_overwriterecords.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_overwriterecords.txt
@@ -1,0 +1,30 @@
+{
+    "cli": "autograder.cli.courses.assignments.submissions.proxy.regrade",
+    "output-check": "content_equals_ignore_time",
+    "arguments": [
+        "--overwrite-records"
+    ]
+}
+---
+{
+    "options": {
+        "dry-run": false,
+        "overwrite-records": true,
+        "wait-for-completion": false,
+        "target-users": [
+            "*"
+        ],
+        "regrade-after": 1234567890123
+    },
+    "regrade-after": 1234567890123,
+    "results": {},
+    "work-errors": {},
+    "complete": false,
+    "resolved-users": [
+        "course-admin@test.edulinq.org",
+        "course-grader@test.edulinq.org",
+        "course-other@test.edulinq.org",
+        "course-owner@test.edulinq.org",
+        "course-student@test.edulinq.org"
+    ]
+}

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_role.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_role.txt
@@ -1,0 +1,26 @@
+{
+    "cli": "autograder.cli.courses.assignments.submissions.proxy.regrade",
+    "output-check": "content_equals_ignore_time",
+    "arguments": [
+        "--target-users", "student"
+    ]
+}
+---
+{
+    "options": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "wait-for-completion": false,
+        "target-users": [
+            "student"
+        ],
+        "regrade-after": 1234567890123
+    },
+    "regrade-after": 1234567890123,
+    "results": {},
+    "work-errors": {},
+    "complete": false,
+    "resolved-users": [
+        "course-student@test.edulinq.org"
+    ]
+}

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_role.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_role.txt
@@ -14,9 +14,8 @@
         "target-users": [
             "student"
         ],
-        "regrade-after": 1234567890123
+        "regrade-cutoff": 1234567890123
     },
-    "regrade-after": 1234567890123,
     "results": {},
     "work-errors": {},
     "complete": false,

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_time.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_time.txt
@@ -1,0 +1,42 @@
+{
+    "cli": "autograder.cli.courses.assignments.submissions.proxy.regrade",
+    "output-check": "content_equals_ignore_time",
+    "arguments": [
+        "--regrade-after", "0"
+    ]
+}
+---
+{
+    "options": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "wait-for-completion": false,
+        "target-users": [
+            "*"
+        ],
+        "regrade-after": 0
+    },
+    "regrade-after": 0,
+    "results": {
+        "course-student@test.edulinq.org": {
+            "id": "course101::hw0::course-student@test.edulinq.org::1234567890",
+            "short-id": "1234567890",
+            "course-id": "course101",
+            "assignment-id": "hw0",
+            "user": "course-student@test.edulinq.org",
+            "message": "",
+            "max_points": 2,
+            "score": 2,
+            "grading_start_time": 1234567890123
+        }
+    },
+    "work-errors": {},
+    "complete": false,
+    "resolved-users": [
+        "course-admin@test.edulinq.org",
+        "course-grader@test.edulinq.org",
+        "course-other@test.edulinq.org",
+        "course-owner@test.edulinq.org",
+        "course-student@test.edulinq.org"
+    ]
+}

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_time.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_time.txt
@@ -2,7 +2,7 @@
     "cli": "autograder.cli.courses.assignments.submissions.proxy.regrade",
     "output-check": "content_equals_ignore_time",
     "arguments": [
-        "--regrade-after", "0"
+        "--regrade-cutoff", "0"
     ]
 }
 ---
@@ -14,9 +14,8 @@
         "target-users": [
             "*"
         ],
-        "regrade-after": 0
+        "regrade-cutoff": 0
     },
-    "regrade-after": 0,
     "results": {
         "course-student@test.edulinq.org": {
             "id": "course101::hw0::course-student@test.edulinq.org::1234567890",

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_wait.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_wait.txt
@@ -1,0 +1,46 @@
+{
+    "cli": "autograder.cli.courses.assignments.submissions.proxy.regrade",
+    "output-check": "content_equals_ignore_time",
+    "arguments": [
+        "--wait-for-completion"
+    ]
+}
+---
+{
+    "options": {
+        "dry-run": false,
+        "overwrite-records": false,
+        "wait-for-completion": true,
+        "target-users": [
+            "*"
+        ],
+        "regrade-after": 1234567890123
+    },
+    "regrade-after": 1234567890123,
+    "results": {
+        "course-admin@test.edulinq.org": null,
+        "course-grader@test.edulinq.org": null,
+        "course-other@test.edulinq.org": null,
+        "course-owner@test.edulinq.org": null,
+        "course-student@test.edulinq.org": {
+            "id": "course101::hw0::course-student@test.edulinq.org::1234567890",
+            "short-id": "1234567890",
+            "course-id": "course101",
+            "assignment-id": "hw0",
+            "user": "course-student@test.edulinq.org",
+            "message": "",
+            "max_points": 2,
+            "score": 2,
+            "grading_start_time": 1234567890123
+        }
+    },
+    "work-errors": {},
+    "complete": true,
+    "resolved-users": [
+        "course-admin@test.edulinq.org",
+        "course-grader@test.edulinq.org",
+        "course-other@test.edulinq.org",
+        "course-owner@test.edulinq.org",
+        "course-student@test.edulinq.org"
+    ]
+}

--- a/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_wait.txt
+++ b/tests/cli/testdata/courses/assignments/proxy/courses_assignments_submissions_proxy_regrade_wait.txt
@@ -14,9 +14,8 @@
         "target-users": [
             "*"
         ],
-        "regrade-after": 1234567890123
+        "regrade-cutoff": 1234567890123
     },
-    "regrade-after": 1234567890123,
     "results": {
         "course-admin@test.edulinq.org": null,
         "course-grader@test.edulinq.org": null,

--- a/tests/cli/testdata/metadata/metadata_describe_base.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_base.txt
@@ -578,7 +578,7 @@
                     "description": "Remove any existing records before running the job."
                 },
                 {
-                    "name": "regrade-after",
+                    "name": "regrade-cutoff",
                     "type": "int64",
                     "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                 },
@@ -614,10 +614,6 @@
                 {
                     "name": "options",
                     "type": "grader.RegradeOptions"
-                },
-                {
-                    "name": "regrade-after",
-                    "type": "int64"
                 },
                 {
                     "name": "resolved-users",
@@ -2037,7 +2033,7 @@
                     "description": "Remove any existing records before running the job."
                 },
                 {
-                    "name": "regrade-after",
+                    "name": "regrade-cutoff",
                     "type": "int64",
                     "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                 },

--- a/tests/cli/testdata/metadata/metadata_describe_base.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_base.txt
@@ -552,6 +552,87 @@
                 }
             ]
         },
+        "courses/assignments/submissions/proxy/regrade": {
+            "description": "Proxy regrade an assignment for all target users using their most recent submission.",
+            "input": [
+                {
+                    "name": "assignment-id",
+                    "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
+                    "required": true
+                },
+                {
+                    "name": "course-id",
+                    "type": "string",
+                    "description": "The ID of the course to make this request to.",
+                    "required": true
+                },
+                {
+                    "name": "dry-run",
+                    "type": "bool",
+                    "description": "Don't save anything."
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool",
+                    "description": "Remove any existing records before running the job."
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64",
+                    "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                },
+                {
+                    "name": "target-users",
+                    "type": "[]model.CourseUserReference",
+                    "description": "The raw course user references to regrade.",
+                    "required": true
+                },
+                {
+                    "name": "user-email",
+                    "type": "string",
+                    "description": "The email of the user making this request.",
+                    "required": true
+                },
+                {
+                    "name": "user-pass",
+                    "type": "string",
+                    "description": "The password of the user making this request.",
+                    "required": true
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool",
+                    "description": "Wait for the entire job to complete and return all results."
+                }
+            ],
+            "output": [
+                {
+                    "name": "complete",
+                    "type": "bool"
+                },
+                {
+                    "name": "options",
+                    "type": "grader.RegradeOptions"
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64"
+                },
+                {
+                    "name": "resolved-users",
+                    "type": "[]string"
+                },
+                {
+                    "name": "results",
+                    "type": "map[string]*model.SubmissionHistoryItem"
+                },
+                {
+                    "name": "work-errors",
+                    "type": "map[string]string"
+                }
+            ]
+        },
         "courses/assignments/submissions/proxy/resubmit": {
             "description": "Proxy resubmit an assignment submission to the autograder.",
             "input": [
@@ -1939,6 +2020,36 @@
                 {
                     "name": "updated",
                     "type": "bool"
+                }
+            ]
+        },
+        "grader.RegradeOptions": {
+            "category": "struct",
+            "fields": [
+                {
+                    "name": "dry-run",
+                    "type": "bool",
+                    "description": "Don't save anything."
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool",
+                    "description": "Remove any existing records before running the job."
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64",
+                    "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                },
+                {
+                    "name": "target-users",
+                    "type": "[]model.CourseUserReference",
+                    "description": "The raw course user references to regrade."
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool",
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ]
         },

--- a/tests/cli/testdata/metadata/metadata_describe_force.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_force.txt
@@ -580,7 +580,7 @@
                     "description": "Remove any existing records before running the job."
                 },
                 {
-                    "name": "regrade-after",
+                    "name": "regrade-cutoff",
                     "type": "int64",
                     "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                 },
@@ -616,10 +616,6 @@
                 {
                     "name": "options",
                     "type": "grader.RegradeOptions"
-                },
-                {
-                    "name": "regrade-after",
-                    "type": "int64"
                 },
                 {
                     "name": "resolved-users",
@@ -2039,7 +2035,7 @@
                     "description": "Remove any existing records before running the job."
                 },
                 {
-                    "name": "regrade-after",
+                    "name": "regrade-cutoff",
                     "type": "int64",
                     "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
                 },

--- a/tests/cli/testdata/metadata/metadata_describe_force.txt
+++ b/tests/cli/testdata/metadata/metadata_describe_force.txt
@@ -554,6 +554,87 @@
                 }
             ]
         },
+        "courses/assignments/submissions/proxy/regrade": {
+            "description": "Proxy regrade an assignment for all target users using their most recent submission.",
+            "input": [
+                {
+                    "name": "assignment-id",
+                    "type": "string",
+                    "description": "The ID of the assignment to make this request to.",
+                    "required": true
+                },
+                {
+                    "name": "course-id",
+                    "type": "string",
+                    "description": "The ID of the course to make this request to.",
+                    "required": true
+                },
+                {
+                    "name": "dry-run",
+                    "type": "bool",
+                    "description": "Don't save anything."
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool",
+                    "description": "Remove any existing records before running the job."
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64",
+                    "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                },
+                {
+                    "name": "target-users",
+                    "type": "[]model.CourseUserReference",
+                    "description": "The raw course user references to regrade.",
+                    "required": true
+                },
+                {
+                    "name": "user-email",
+                    "type": "string",
+                    "description": "The email of the user making this request.",
+                    "required": true
+                },
+                {
+                    "name": "user-pass",
+                    "type": "string",
+                    "description": "The password of the user making this request.",
+                    "required": true
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool",
+                    "description": "Wait for the entire job to complete and return all results."
+                }
+            ],
+            "output": [
+                {
+                    "name": "complete",
+                    "type": "bool"
+                },
+                {
+                    "name": "options",
+                    "type": "grader.RegradeOptions"
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64"
+                },
+                {
+                    "name": "resolved-users",
+                    "type": "[]string"
+                },
+                {
+                    "name": "results",
+                    "type": "map[string]*model.SubmissionHistoryItem"
+                },
+                {
+                    "name": "work-errors",
+                    "type": "map[string]string"
+                }
+            ]
+        },
         "courses/assignments/submissions/proxy/resubmit": {
             "description": "Proxy resubmit an assignment submission to the autograder.",
             "input": [
@@ -1941,6 +2022,36 @@
                 {
                     "name": "updated",
                     "type": "bool"
+                }
+            ]
+        },
+        "grader.RegradeOptions": {
+            "category": "struct",
+            "fields": [
+                {
+                    "name": "dry-run",
+                    "type": "bool",
+                    "description": "Don't save anything."
+                },
+                {
+                    "name": "overwrite-records",
+                    "type": "bool",
+                    "description": "Remove any existing records before running the job."
+                },
+                {
+                    "name": "regrade-after",
+                    "type": "int64",
+                    "description": "Ensure every user has made a new submission after this time.\nIf nil, the current time will be used."
+                },
+                {
+                    "name": "target-users",
+                    "type": "[]model.CourseUserReference",
+                    "description": "The raw course user references to regrade."
+                },
+                {
+                    "name": "wait-for-completion",
+                    "type": "bool",
+                    "description": "Wait for the entire job to complete and return all results."
                 }
             ]
         },


### PR DESCRIPTION
This PR adds support for the new `courses/assignments/submissions/proxy/regrade` API endpoint. It also updates the testdata to match the new (future) version of the server.

This PR depends on the [corresponding server changes](https://github.com/edulinq/autograder-server/pull/195). Once the server changes are merged, a new version of the server must be deployed so this PR can pass CI.