### PR TITLE
Course Gradebook Endpoint Interface

### DIFF
--- a/autograder/api/config.py
+++ b/autograder/api/config.py
@@ -333,7 +333,7 @@ PARAM_COURSE = APIParam(
 
 PARAM_COURSE_USER_REFERENCES = APIParam(
     'target_users',
-    ('A list of course user references.'
+    ('A CSV list of course user references.'
     + ' Course user references may be specified in four ways:'
     + ' 1) Email address of the requested user,'
     + ' 2) "*" to request all users in the course,'
@@ -364,7 +364,7 @@ PARAM_EMAIL_BODY = APIParam(
 
 PARAM_EMAIL_COURSE_BCC = APIParam(
     'bcc',
-    'A list of email addresses. Accepts course user references.',
+    'A CSV list of email addresses. Accepts course user references.',
     api_required = False,
     value_type = list,
     cli_action = 'extend',
@@ -374,7 +374,7 @@ PARAM_EMAIL_COURSE_BCC = APIParam(
 
 PARAM_EMAIL_COURSE_CC = APIParam(
     'cc',
-    'A list of email addresses. Accepts course user references.',
+    'A CSV list of email addresses. Accepts course user references.',
     api_required = False,
     value_type = list,
     cli_action = 'extend',
@@ -384,7 +384,7 @@ PARAM_EMAIL_COURSE_CC = APIParam(
 
 PARAM_EMAIL_COURSE_TO = APIParam(
     'to',
-    ('A list of email addresses.'
+    ('A CSV list of email addresses.'
     + ' Accepts course user references.'
     + ' Course user references may be specified in four ways:'
     + ' 1) Email address of the requested user,'
@@ -805,7 +805,7 @@ PARAM_SUBMISSION_SPECS = APIParam(
 
 PARAM_TARGET_ASSIGNMENTS = APIParam(
     'target_assignments',
-    ('A list of assignment IDs to target.'
+    ('A CSV list of assignment IDs to target.'
     + ' Default: All assignments in the course.'),
     api_required = False,
     value_type = list,
@@ -833,7 +833,7 @@ PARAM_TARGET_USER_OR_SELF = APIParam(
 
 PARAM_TARGET_USERS = APIParam(
     'target_users',
-    ('A list of server user references.'
+    ('A CSV list of server user references.'
     + ' Server user references may be specified in eight ways:'
     + ' 1) Email address of the requested user,'
     + ' 2) "*" to request all users in the server,'

--- a/autograder/api/config.py
+++ b/autograder/api/config.py
@@ -803,6 +803,17 @@ PARAM_SUBMISSION_SPECS = APIParam(
     cli_add_func = _cli_add_func_submission_specs,
 )
 
+PARAM_TARGET_ASSIGNMENTS = APIParam(
+    'target_assignments',
+    ('A list of assignment IDs to target.'
+    + ' Default: All assignments in the course.'),
+    api_required = False,
+    value_type = list,
+    cli_action = 'extend',
+    cli_type = _csv_to_list,
+    cli_show_default = False,
+)
+
 PARAM_TARGET_EMAIL = APIParam(
     'target_email',
     'The email of the user that is the target of this request.',

--- a/autograder/api/courses/gradebook/fetch.py
+++ b/autograder/api/courses/gradebook/fetch.py
@@ -22,5 +22,6 @@ API_PARAMS: typing.List[autograder.api.config.APIParam] = [
 ]
 
 def send(config: autograder.model.config.Config, **kwargs: typing.Any) -> typing.Dict[str, typing.Any]:
+    """ Send a request to the autograder. """
 
     return autograder.api.common.make_api_request(API_ENDPOINT, config, API_PARAMS, write = API_WRITE, **kwargs)

--- a/autograder/api/courses/gradebook/fetch.py
+++ b/autograder/api/courses/gradebook/fetch.py
@@ -4,8 +4,13 @@ Fetch a gradebook for this course.
 
 import typing
 
+import lms.model.assignments
+import lms.model.scores
+import lms.model.users
+
 import autograder.api.common
 import autograder.api.config
+import autograder.model.assignment
 import autograder.model.config
 
 API_ENDPOINT: str = 'courses/gradebook/fetch'
@@ -21,7 +26,27 @@ API_PARAMS: typing.List[autograder.api.config.APIParam] = [
     autograder.api.config.PARAM_TARGET_ASSIGNMENTS,
 ]
 
-def send(config: autograder.model.config.Config, **kwargs: typing.Any) -> typing.Dict[str, typing.Any]:
+def send(config: autograder.model.config.Config, **kwargs: typing.Any) -> lms.model.scores.Gradebook:
     """ Send a request to the autograder. """
 
-    return autograder.api.common.make_api_request(API_ENDPOINT, config, API_PARAMS, write = API_WRITE, **kwargs)
+    response = autograder.api.common.make_api_request(API_ENDPOINT, config, API_PARAMS, write = API_WRITE, **kwargs)
+
+    assignment_queries: typing.List[lms.model.assignments.AssignmentQuery] = []
+    user_queries: typing.List[lms.model.users.UserQuery] = []
+
+    for assignment_id in response['gradebook']:
+        assignment_queries.append(lms.model.assignments.AssignmentQuery(id = assignment_id))
+        if (not user_queries):
+            for user_email in response['gradebook'][assignment_id]:
+                user_queries.append(lms.model.users.UserQuery(id = user_email))
+
+    gradebook = lms.model.scores.Gradebook(assignment_queries, user_queries)
+
+    for user_scores in response['gradebook'].values():
+        for raw_score in user_scores.values():
+            if (raw_score is not None):
+                score = autograder.model.assignment.make_assignment_score(raw_score)
+                score.user = lms.model.users.UserQuery(id = raw_score['user'])
+                gradebook.add(score)
+
+    return gradebook

--- a/autograder/api/courses/gradebook/fetch.py
+++ b/autograder/api/courses/gradebook/fetch.py
@@ -34,10 +34,10 @@ def send(config: autograder.model.config.Config, **kwargs: typing.Any) -> lms.mo
     assignment_queries: typing.List[lms.model.assignments.AssignmentQuery] = []
     user_queries: typing.List[lms.model.users.UserQuery] = []
 
-    for assignment_id in response['gradebook']:
+    for (assignment_id, user_scores) in response['gradebook'].items():
         assignment_queries.append(lms.model.assignments.AssignmentQuery(id = assignment_id))
-        if (not user_queries):
-            for user_email in response['gradebook'][assignment_id]:
+        if (len(user_queries) == 0):
+            for user_email in user_scores:
                 user_queries.append(lms.model.users.UserQuery(id = user_email))
 
     gradebook = lms.model.scores.Gradebook(assignment_queries, user_queries)

--- a/autograder/api/courses/gradebook/fetch.py
+++ b/autograder/api/courses/gradebook/fetch.py
@@ -1,0 +1,26 @@
+"""
+Fetch a gradebook for this course.
+"""
+
+import typing
+
+import autograder.api.common
+import autograder.api.config
+import autograder.model.config
+
+API_ENDPOINT: str = 'courses/gradebook/fetch'
+API_WRITE: bool = False
+API_PARAMS: typing.List[autograder.api.config.APIParam] = [
+    autograder.api.config.PARAM_SERVER,
+    autograder.api.config.PARAM_USER_EMAIL,
+    autograder.api.config.PARAM_USER_PASS,
+
+    autograder.api.config.PARAM_COURSE,
+
+    autograder.api.config.PARAM_COURSE_USER_REFERENCES,
+    autograder.api.config.PARAM_TARGET_ASSIGNMENTS,
+]
+
+def send(config: autograder.model.config.Config, **kwargs: typing.Any) -> typing.Dict[str, typing.Any]:
+
+    return autograder.api.common.make_api_request(API_ENDPOINT, config, API_PARAMS, write = API_WRITE, **kwargs)

--- a/autograder/api/courses/gradebook/fetch_test.py
+++ b/autograder/api/courses/gradebook/fetch_test.py
@@ -65,6 +65,40 @@ class TestCoursesGradebookFetch(autograder.testing.server.ServerTest):
                 },
                 None,
             ),
+            (
+                autograder.model.config.Config(
+                    auth_user = 'course-grader@test.edulinq.org',
+                    auth_pass = edq.util.crypto.Secret('course-grader'),
+
+                    course = 'course-languages',
+
+                    target_users = ['student'],
+                    target_assignments = ['bash', 'cpp'],
+
+                ),
+                {},
+                {
+                    "gradebook": {
+                        "bash": {
+                            "course-student@test.edulinq.org": {
+                                "assignment-id": "bash",
+                                "course-id": "course-languages",
+                                "grading_start_time": 1768603685040,
+                                "id": "course-languages::bash::course-student@test.edulinq.org::1768603685",
+                                "max_points": 10,
+                                "message": "",
+                                "score": 10,
+                                "short-id": "1768603685",
+                                "user": "course-student@test.edulinq.org"
+                            }
+                        },
+                        "cpp": {
+                            "course-student@test.edulinq.org": None
+                        }
+                    }
+                },
+                None,
+            ),
         ]
 
         self.base_api_test(autograder.api.courses.gradebook.fetch.send, test_cases)

--- a/autograder/api/courses/gradebook/fetch_test.py
+++ b/autograder/api/courses/gradebook/fetch_test.py
@@ -1,6 +1,10 @@
 import typing
 
 import edq.util.crypto
+import edq.util.time
+import lms.model.assignments
+import lms.model.scores
+import lms.model.users
 
 import autograder.api.config
 import autograder.api.courses.gradebook.fetch
@@ -28,41 +32,7 @@ class TestCoursesGradebookFetch(autograder.testing.server.ServerTest):
                     course = 'course-languages',
                 ),
                 {},
-                {
-                    "gradebook": {
-                        "bash": {
-                            "course-admin@test.edulinq.org": None,
-                            "course-grader@test.edulinq.org": None,
-                            "course-other@test.edulinq.org": None,
-                            "course-owner@test.edulinq.org": None,
-                            "course-student@test.edulinq.org": {
-                                "assignment-id": "bash",
-                                "course-id": "course-languages",
-                                "grading_start_time": 1768603685040,
-                                "id": "course-languages::bash::course-student@test.edulinq.org::1768603685",
-                                "max_points": 10,
-                                "message": "",
-                                "score": 10,
-                                "short-id": "1768603685",
-                                "user": "course-student@test.edulinq.org"
-                            }
-                        },
-                        "cpp": {
-                            "course-admin@test.edulinq.org": None,
-                            "course-grader@test.edulinq.org": None,
-                            "course-other@test.edulinq.org": None,
-                            "course-owner@test.edulinq.org": None,
-                            "course-student@test.edulinq.org": None
-                        },
-                        "java": {
-                            "course-admin@test.edulinq.org": None,
-                            "course-grader@test.edulinq.org": None,
-                            "course-other@test.edulinq.org": None,
-                            "course-owner@test.edulinq.org": None,
-                            "course-student@test.edulinq.org": None
-                        }
-                    }
-                },
+                BASE_GRADEBOOK,
                 None,
             ),
 
@@ -73,31 +43,46 @@ class TestCoursesGradebookFetch(autograder.testing.server.ServerTest):
                     auth_pass = edq.util.crypto.Secret('course-grader'),
                     course = 'course-languages',
                     target_users = ['student'],
-                    target_assignments = ['bash', 'cpp'],
+                    target_assignments = ['cpp', 'java'],
                 ),
                 {},
-                {
-                    "gradebook": {
-                        "bash": {
-                            "course-student@test.edulinq.org": {
-                                "assignment-id": "bash",
-                                "course-id": "course-languages",
-                                "grading_start_time": 1768603685040,
-                                "id": "course-languages::bash::course-student@test.edulinq.org::1768603685",
-                                "max_points": 10,
-                                "message": "",
-                                "score": 10,
-                                "short-id": "1768603685",
-                                "user": "course-student@test.edulinq.org"
-                            }
-                        },
-                        "cpp": {
-                            "course-student@test.edulinq.org": None
-                        }
-                    }
-                },
+                FILTERED_GRADEBOOK,
                 None,
             ),
         ]
 
         self.base_api_test(autograder.api.courses.gradebook.fetch.send, test_cases)
+
+BASE_GRADEBOOK: lms.model.scores.Gradebook = lms.model.scores.Gradebook(
+    [
+        lms.model.assignments.AssignmentQuery(id = 'bash'),
+        lms.model.assignments.AssignmentQuery(id = 'cpp'),
+        lms.model.assignments.AssignmentQuery(id = 'java'),
+    ],
+    [
+        lms.model.users.UserQuery(id = 'course-admin@test.edulinq.org'),
+        lms.model.users.UserQuery(id = 'course-grader@test.edulinq.org'),
+        lms.model.users.UserQuery(id = 'course-other@test.edulinq.org'),
+        lms.model.users.UserQuery(id = 'course-owner@test.edulinq.org'),
+        lms.model.users.UserQuery(id = 'course-student@test.edulinq.org'),
+    ],
+)
+BASE_GRADEBOOK.add(lms.model.scores.AssignmentScore(
+    assignment = lms.model.assignments.AssignmentQuery(id = 'bash'),
+    user = lms.model.users.UserQuery(id = 'course-student@test.edulinq.org'),
+    id = 'course-languages::bash::course-student@test.edulinq.org::1768603685',
+    score = 10,
+    comment = '',
+    graded_date = edq.util.time.Timestamp(1768603685040),
+    submission_date = edq.util.time.Timestamp(1768603685040),
+))
+
+FILTERED_GRADEBOOK: lms.model.scores.Gradebook = lms.model.scores.Gradebook(
+    [
+        lms.model.assignments.AssignmentQuery(id = 'cpp'),
+        lms.model.assignments.AssignmentQuery(id = 'java'),
+    ],
+    [
+        lms.model.users.UserQuery(id = 'course-student@test.edulinq.org'),
+    ],
+)

--- a/autograder/api/courses/gradebook/fetch_test.py
+++ b/autograder/api/courses/gradebook/fetch_test.py
@@ -20,11 +20,11 @@ class TestCoursesGradebookFetch(autograder.testing.server.ServerTest):
             typing.Any,
             typing.Union[str, None],
         ]] = [
+            # Full Gradebook
             (
                 autograder.model.config.Config(
                     auth_user = 'course-grader@test.edulinq.org',
                     auth_pass = edq.util.crypto.Secret('course-grader'),
-
                     course = 'course-languages',
                 ),
                 {},
@@ -65,16 +65,15 @@ class TestCoursesGradebookFetch(autograder.testing.server.ServerTest):
                 },
                 None,
             ),
+
+            # Filtered Gradebook
             (
                 autograder.model.config.Config(
                     auth_user = 'course-grader@test.edulinq.org',
                     auth_pass = edq.util.crypto.Secret('course-grader'),
-
                     course = 'course-languages',
-
                     target_users = ['student'],
                     target_assignments = ['bash', 'cpp'],
-
                 ),
                 {},
                 {

--- a/autograder/api/courses/gradebook/fetch_test.py
+++ b/autograder/api/courses/gradebook/fetch_test.py
@@ -1,0 +1,37 @@
+import typing
+
+import edq.util.crypto
+
+import autograder.api.config
+import autograder.api.courses.gradebook.fetch
+import autograder.model.config
+import autograder.testing.server
+
+class TestCoursesGradebookFetch(autograder.testing.server.ServerTest):
+    """ Test fetching a course gradebook. """
+
+    def test_base(self) -> None:
+        """ Test base functionality. """
+
+        # [(config (and overrides), kwargs, expected, error substring), ...]
+        test_cases: typing.List[typing.Tuple[
+            autograder.model.config.Config,
+            typing.Dict[str, typing.Any],
+            typing.Any,
+            typing.Union[str, None],
+        ]] = [
+            (
+                autograder.model.config.Config(
+                    auth_user = 'course-grader@test.edulinq.org',
+                    auth_pass = edq.util.crypto.Secret('course-grader'),
+
+                    course = 'course101',
+
+                ),
+                {},
+                {},
+                None,
+            ),
+        ]
+
+        self.base_api_test(autograder.api.courses.gradebook.fetch.send, test_cases)

--- a/autograder/api/courses/gradebook/fetch_test.py
+++ b/autograder/api/courses/gradebook/fetch_test.py
@@ -25,28 +25,41 @@ class TestCoursesGradebookFetch(autograder.testing.server.ServerTest):
                     auth_user = 'course-grader@test.edulinq.org',
                     auth_pass = edq.util.crypto.Secret('course-grader'),
 
-                    course = 'course101',
-
+                    course = 'course-languages',
                 ),
                 {},
                 {
                     "gradebook": {
-                        "hw0": {
+                        "bash": {
                             "course-admin@test.edulinq.org": None,
                             "course-grader@test.edulinq.org": None,
                             "course-other@test.edulinq.org": None,
                             "course-owner@test.edulinq.org": None,
                             "course-student@test.edulinq.org": {
-                                "assignment-id": "hw0",
-                                "course-id": "course101",
-                                "grading_start_time": 1697406273000,
-                                "id": "course101::hw0::course-student@test.edulinq.org::1697406272",
-                                "max_points": 2,
+                                "assignment-id": "bash",
+                                "course-id": "course-languages",
+                                "grading_start_time": 1768603685040,
+                                "id": "course-languages::bash::course-student@test.edulinq.org::1768603685",
+                                "max_points": 10,
                                 "message": "",
-                                "score": 2,
-                                "short-id": "1697406272",
+                                "score": 10,
+                                "short-id": "1768603685",
                                 "user": "course-student@test.edulinq.org"
                             }
+                        },
+                        "cpp": {
+                            "course-admin@test.edulinq.org": None,
+                            "course-grader@test.edulinq.org": None,
+                            "course-other@test.edulinq.org": None,
+                            "course-owner@test.edulinq.org": None,
+                            "course-student@test.edulinq.org": None
+                        },
+                        "java": {
+                            "course-admin@test.edulinq.org": None,
+                            "course-grader@test.edulinq.org": None,
+                            "course-other@test.edulinq.org": None,
+                            "course-owner@test.edulinq.org": None,
+                            "course-student@test.edulinq.org": None
                         }
                     }
                 },

--- a/autograder/api/courses/gradebook/fetch_test.py
+++ b/autograder/api/courses/gradebook/fetch_test.py
@@ -67,6 +67,7 @@ BASE_GRADEBOOK: lms.model.scores.Gradebook = lms.model.scores.Gradebook(
         lms.model.users.UserQuery(id = 'course-student@test.edulinq.org'),
     ],
 )
+
 BASE_GRADEBOOK.add(lms.model.scores.AssignmentScore(
     assignment = lms.model.assignments.AssignmentQuery(id = 'bash'),
     user = lms.model.users.UserQuery(id = 'course-student@test.edulinq.org'),

--- a/autograder/api/courses/gradebook/fetch_test.py
+++ b/autograder/api/courses/gradebook/fetch_test.py
@@ -29,7 +29,27 @@ class TestCoursesGradebookFetch(autograder.testing.server.ServerTest):
 
                 ),
                 {},
-                {},
+                {
+                    "gradebook": {
+                        "hw0": {
+                            "course-admin@test.edulinq.org": None,
+                            "course-grader@test.edulinq.org": None,
+                            "course-other@test.edulinq.org": None,
+                            "course-owner@test.edulinq.org": None,
+                            "course-student@test.edulinq.org": {
+                                "assignment-id": "hw0",
+                                "course-id": "course101",
+                                "grading_start_time": 1697406273000,
+                                "id": "course101::hw0::course-student@test.edulinq.org::1697406272",
+                                "max_points": 2,
+                                "message": "",
+                                "score": 2,
+                                "short-id": "1697406272",
+                                "user": "course-student@test.edulinq.org"
+                            }
+                        }
+                    }
+                },
                 None,
             ),
         ]

--- a/autograder/cli/courses/gradebook/__init__.py
+++ b/autograder/cli/courses/gradebook/__init__.py
@@ -1,0 +1,3 @@
+"""
+The `autograder.cli.courses.gradebook` package contains tools to work with a course-level gradebook.
+"""

--- a/autograder/cli/courses/gradebook/__main__.py
+++ b/autograder/cli/courses/gradebook/__main__.py
@@ -1,0 +1,11 @@
+import sys
+
+import edq.clilib.list
+
+def main() -> int:
+    """ List this CLI dir. """
+
+    return edq.clilib.list.main()
+
+if (__name__ == '__main__'):
+    sys.exit(main())

--- a/autograder/cli/courses/gradebook/fetch.py
+++ b/autograder/cli/courses/gradebook/fetch.py
@@ -38,7 +38,8 @@ def _get_parser() -> argparse.ArgumentParser:
     parser = autograder.cli.parser.get_parser(
         __doc__.strip(),
         autograder.api.courses.gradebook.fetch.API_PARAMS,
-        include_output_format = True,)
+        include_output_format = True,
+    )
 
     return parser
 

--- a/autograder/cli/courses/gradebook/fetch.py
+++ b/autograder/cli/courses/gradebook/fetch.py
@@ -5,7 +5,7 @@ Fetch a course gradebook.
 import argparse
 import sys
 
-import edq.util.json
+import lms.model.base
 
 import autograder.api.courses.gradebook.fetch
 import autograder.cli.parser
@@ -15,8 +15,15 @@ def run_cli(args: argparse.Namespace) -> int:
 
     config = args._config_info.application_config
 
-    result = autograder.api.courses.gradebook.fetch.send(config, exit_on_error = True)
-    print(edq.util.json.dumps(result, indent = 4))
+    gradebook = autograder.api.courses.gradebook.fetch.send(config, exit_on_error = True)
+
+    output = lms.model.base.base_list_to_output_format([gradebook], config.output_format,
+            skip_headers = args.skip_headers,
+            pretty_headers = args.pretty_headers,
+            include_extra_fields = args.include_extra_fields,
+            extract_single_list = True,
+    )
+    print(output)
 
     return 0
 
@@ -30,7 +37,8 @@ def _get_parser() -> argparse.ArgumentParser:
 
     parser = autograder.cli.parser.get_parser(
         __doc__.strip(),
-        autograder.api.courses.gradebook.fetch.API_PARAMS)
+        autograder.api.courses.gradebook.fetch.API_PARAMS,
+        include_output_format = True,)
 
     return parser
 

--- a/autograder/cli/courses/gradebook/fetch.py
+++ b/autograder/cli/courses/gradebook/fetch.py
@@ -1,0 +1,38 @@
+"""
+Fetch a course gradebook.
+"""
+
+import argparse
+import sys
+
+import edq.util.json
+
+import autograder.api.courses.gradebook.fetch
+import autograder.cli.parser
+
+def run_cli(args: argparse.Namespace) -> int:
+    """ Run the CLI. """
+
+    config = args._config_info.application_config
+
+    result = autograder.api.courses.gradebook.fetch.send(config, exit_on_error = True)
+    print(edq.util.json.dumps(result, indent = 4))
+
+    return 0
+
+def main() -> int:
+    """ Get a parser, parse the args, and call run. """
+
+    return run_cli(_get_parser().parse_args())
+
+def _get_parser() -> argparse.ArgumentParser:
+    """ Get a parser for this operation. """
+
+    parser = autograder.cli.parser.get_parser(
+        __doc__.strip(),
+        autograder.api.courses.gradebook.fetch.API_PARAMS)
+
+    return parser
+
+if (__name__ == '__main__'):
+    sys.exit(main())

--- a/autograder/cli/testdata/tests/courses/gradebook/fetch_base.txt
+++ b/autograder/cli/testdata/tests/courses/gradebook/fetch_base.txt
@@ -7,38 +7,27 @@
     ],
 }
 ---
-{
-    "gradebook": {
-        "bash": {
-            "course-admin@test.edulinq.org": null,
-            "course-grader@test.edulinq.org": null,
-            "course-other@test.edulinq.org": null,
-            "course-owner@test.edulinq.org": null,
-            "course-student@test.edulinq.org": {
-                "assignment-id": "bash",
-                "course-id": "course-languages",
-                "grading_start_time": 1768603685040,
-                "id": "course-languages::bash::course-student@test.edulinq.org::1768603685",
-                "max_points": 10,
-                "message": "",
-                "score": 10,
-                "short-id": "1768603685",
-                "user": "course-student@test.edulinq.org"
-            }
-        },
-        "cpp": {
-            "course-admin@test.edulinq.org": null,
-            "course-grader@test.edulinq.org": null,
-            "course-other@test.edulinq.org": null,
-            "course-owner@test.edulinq.org": null,
-            "course-student@test.edulinq.org": null
-        },
-        "java": {
-            "course-admin@test.edulinq.org": null,
-            "course-grader@test.edulinq.org": null,
-            "course-other@test.edulinq.org": null,
-            "course-owner@test.edulinq.org": null,
-            "course-student@test.edulinq.org": null
-        }
-    }
-}
+User: course-admin@test.edulinq.org
+bash: 
+cpp: 
+java: 
+
+User: course-grader@test.edulinq.org
+bash: 
+cpp: 
+java: 
+
+User: course-other@test.edulinq.org
+bash: 
+cpp: 
+java: 
+
+User: course-owner@test.edulinq.org
+bash: 
+cpp: 
+java: 
+
+User: course-student@test.edulinq.org
+bash: 10
+cpp: 
+java: 

--- a/autograder/cli/testdata/tests/courses/gradebook/fetch_base.txt
+++ b/autograder/cli/testdata/tests/courses/gradebook/fetch_base.txt
@@ -1,7 +1,7 @@
 {
     "cli": "autograder.cli.courses.gradebook.fetch",
     "arguments": [
-        '--course', 'course101',
+        '--course', 'course-languages',
         '--user', 'course-grader@test.edulinq.org',
         '--pass', 'course-grader',
     ],
@@ -9,22 +9,36 @@
 ---
 {
     "gradebook": {
-        "hw0": {
+        "bash": {
             "course-admin@test.edulinq.org": null,
             "course-grader@test.edulinq.org": null,
             "course-other@test.edulinq.org": null,
             "course-owner@test.edulinq.org": null,
             "course-student@test.edulinq.org": {
-                "assignment-id": "hw0",
-                "course-id": "course101",
-                "grading_start_time": 1697406273000,
-                "id": "course101::hw0::course-student@test.edulinq.org::1697406272",
-                "max_points": 2,
+                "assignment-id": "bash",
+                "course-id": "course-languages",
+                "grading_start_time": 1768603685040,
+                "id": "course-languages::bash::course-student@test.edulinq.org::1768603685",
+                "max_points": 10,
                 "message": "",
-                "score": 2,
-                "short-id": "1697406272",
+                "score": 10,
+                "short-id": "1768603685",
                 "user": "course-student@test.edulinq.org"
             }
+        },
+        "cpp": {
+            "course-admin@test.edulinq.org": null,
+            "course-grader@test.edulinq.org": null,
+            "course-other@test.edulinq.org": null,
+            "course-owner@test.edulinq.org": null,
+            "course-student@test.edulinq.org": null
+        },
+        "java": {
+            "course-admin@test.edulinq.org": null,
+            "course-grader@test.edulinq.org": null,
+            "course-other@test.edulinq.org": null,
+            "course-owner@test.edulinq.org": null,
+            "course-student@test.edulinq.org": null
         }
     }
 }

--- a/autograder/cli/testdata/tests/courses/gradebook/fetch_base.txt
+++ b/autograder/cli/testdata/tests/courses/gradebook/fetch_base.txt
@@ -1,0 +1,30 @@
+{
+    "cli": "autograder.cli.courses.gradebook.fetch",
+    "arguments": [
+        '--course', 'course101',
+        '--user', 'course-grader@test.edulinq.org',
+        '--pass', 'course-grader',
+    ],
+}
+---
+{
+    "gradebook": {
+        "hw0": {
+            "course-admin@test.edulinq.org": null,
+            "course-grader@test.edulinq.org": null,
+            "course-other@test.edulinq.org": null,
+            "course-owner@test.edulinq.org": null,
+            "course-student@test.edulinq.org": {
+                "assignment-id": "hw0",
+                "course-id": "course101",
+                "grading_start_time": 1697406273000,
+                "id": "course101::hw0::course-student@test.edulinq.org::1697406272",
+                "max_points": 2,
+                "message": "",
+                "score": 2,
+                "short-id": "1697406272",
+                "user": "course-student@test.edulinq.org"
+            }
+        }
+    }
+}

--- a/autograder/cli/testdata/tests/courses/gradebook/fetch_filtered.txt
+++ b/autograder/cli/testdata/tests/courses/gradebook/fetch_filtered.txt
@@ -1,0 +1,31 @@
+{
+    "cli": "autograder.cli.courses.gradebook.fetch",
+    "arguments": [
+        '--course', 'course-languages',
+        '--user', 'course-grader@test.edulinq.org',
+        '--pass', 'course-grader',
+        '--target-users', 'student',
+        '--target-assignments', 'bash,cpp'
+    ],
+}
+---
+{
+    "gradebook": {
+        "bash": {
+            "course-student@test.edulinq.org": {
+                "assignment-id": "bash",
+                "course-id": "course-languages",
+                "grading_start_time": 1768603685040,
+                "id": "course-languages::bash::course-student@test.edulinq.org::1768603685",
+                "max_points": 10,
+                "message": "",
+                "score": 10,
+                "short-id": "1768603685",
+                "user": "course-student@test.edulinq.org"
+            }
+        },
+        "cpp": {
+            "course-student@test.edulinq.org": null
+        }
+    }
+}

--- a/autograder/cli/testdata/tests/courses/gradebook/fetch_filtered.txt
+++ b/autograder/cli/testdata/tests/courses/gradebook/fetch_filtered.txt
@@ -5,27 +5,10 @@
         '--user', 'course-grader@test.edulinq.org',
         '--pass', 'course-grader',
         '--target-users', 'student',
-        '--target-assignments', 'bash,cpp'
+        '--target-assignments', 'cpp,java'
     ],
 }
 ---
-{
-    "gradebook": {
-        "bash": {
-            "course-student@test.edulinq.org": {
-                "assignment-id": "bash",
-                "course-id": "course-languages",
-                "grading_start_time": 1768603685040,
-                "id": "course-languages::bash::course-student@test.edulinq.org::1768603685",
-                "max_points": 10,
-                "message": "",
-                "score": 10,
-                "short-id": "1768603685",
-                "user": "course-student@test.edulinq.org"
-            }
-        },
-        "cpp": {
-            "course-student@test.edulinq.org": null
-        }
-    }
-}
+User: course-student@test.edulinq.org
+cpp: 
+java: 

--- a/autograder/cli/testdata/tests/courses/gradebook/fetch_table.txt
+++ b/autograder/cli/testdata/tests/courses/gradebook/fetch_table.txt
@@ -1,0 +1,16 @@
+{
+    "cli": "autograder.cli.courses.gradebook.fetch",
+    "arguments": [
+        '--course', 'course-languages',
+        '--user', 'course-grader@test.edulinq.org',
+        '--pass', 'course-grader',
+        '--format', 'table',
+    ],
+}
+---
+User	bash	cpp	java
+course-admin@test.edulinq.org			
+course-grader@test.edulinq.org			
+course-other@test.edulinq.org			
+course-owner@test.edulinq.org			
+course-student@test.edulinq.org	10		

--- a/autograder/model/config.py
+++ b/autograder/model/config.py
@@ -81,6 +81,7 @@ class Config(edq.config.app.BaseApplicationConfig):
             skip_updates: typing.Union[bool, None] = None,
             subject: typing.Union[str, None] = None,
             submission_specs: typing.Union[typing.List[str], None] = None,
+            target_assignments: typing.Union[typing.List[str], None] = None,
             target_email: typing.Union[str, None] = None,
             target_submission: typing.Union[str, None] = None,
             target_users: typing.Union[typing.List[str], None] = None,
@@ -287,6 +288,9 @@ class Config(edq.config.app.BaseApplicationConfig):
 
         self.submission_specs: typing.Union[typing.List[str], None] = submission_specs
         """ A list of submission specifications. """
+
+        self.target_assignments: typing.Union[typing.List[str], None] = target_assignments
+        """ A list of assignment IDs. """
 
         self.target_email: typing.Union[str, None] = target_email
         """ The email of the user that is the target of this request. """


### PR DESCRIPTION
Adds interface support for the Gradebook endpoint in edulinq/autograder-server/pull/228. Includes both API and CLI testing, currently checking if both a complete and filtered gradebook can be returned in its raw form. Tests currently pass, but waiting on merge in autograder-server to pass CI.